### PR TITLE
Add homepage/SCM info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,13 @@ organization := "io.github.davidgregory084"
 organizationName := "David Gregory"
 startYear := Some(2019)
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
+scmInfo := Some(
+  ScmInfo(
+    url("https://github.com/DavidGregory084/sbt-tpolecat"),
+    "scm:git:git@github.com:DavidGregory084/sbt-tpolecat.git"
+  )
+)
+homepage := scmInfo.value.map(_.browseUrl)
 
 crossSbtVersions := Seq("0.13.18", "1.2.8")
 


### PR DESCRIPTION
So [Scala Steward](https://github.com/fthomas/scala-steward) and [Scaladex](https://index.scala-lang.org/) can know the home of the published artifact.