### PR TITLE
explicits && nowarn

### DIFF
--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -81,6 +81,8 @@ object TpolecatPlugin extends AutoPlugin {
     ScalacOption("-Ywarn-unused-import", addedIn = Some(11), removedIn = Some(12)), // Warn if an import selector is not referenced.
     ScalacOption("-Ywarn-unused:implicits", addedIn = Some(12), removedIn = Some(13)),           // Warn if an implicit parameter is unused.
     ScalacOption("-Wunused:implicits", addedIn = Some(13), removedIn = dotty),                   // ^ Replaces the above
+    ScalacOption("-Ywarn-unused:explicits", addedIn = Some(13), removedIn = dotty),              // Warn if an explicit parameter is unused.
+    ScalacOption("-Wunused:explicits", addedIn = Some(13), removedIn = dotty),                   // ^ Replaces the above
     ScalacOption("-Ywarn-unused:imports", addedIn = Some(12), removedIn = Some(13)),             // Warn if an import selector is not referenced.
     ScalacOption("-Wunused:imports", addedIn = Some(13), removedIn = dotty),                     // ^ Replaces the above
     ScalacOption("-Ywarn-unused:locals", addedIn = Some(12), removedIn = Some(13)),              // Warn if a local definition is unused.

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -81,8 +81,7 @@ object TpolecatPlugin extends AutoPlugin {
     ScalacOption("-Ywarn-unused-import", addedIn = Some(11), removedIn = Some(12)), // Warn if an import selector is not referenced.
     ScalacOption("-Ywarn-unused:implicits", addedIn = Some(12), removedIn = Some(13)),           // Warn if an implicit parameter is unused.
     ScalacOption("-Wunused:implicits", addedIn = Some(13), removedIn = dotty),                   // ^ Replaces the above
-    ScalacOption("-Ywarn-unused:explicits", addedIn = Some(13), removedIn = dotty),              // Warn if an explicit parameter is unused.
-    ScalacOption("-Wunused:explicits", addedIn = Some(13), removedIn = dotty),                   // ^ Replaces the above
+    ScalacOption("-Wunused:explicits", addedIn = Some(13), removedIn = dotty),                   // Warn if an explicit parameter is unused.
     ScalacOption("-Ywarn-unused:imports", addedIn = Some(12), removedIn = Some(13)),             // Warn if an import selector is not referenced.
     ScalacOption("-Wunused:imports", addedIn = Some(13), removedIn = dotty),                     // ^ Replaces the above
     ScalacOption("-Ywarn-unused:locals", addedIn = Some(12), removedIn = Some(13)),              // Warn if a local definition is unused.


### PR DESCRIPTION
I currently see this when I compile:

```
sbt:pstor-root> test:compile
[warn] There may be incompatibilities among your library dependencies; run 'evicted' to see detailed eviction warnings.
[info] Compiling 1 Scala source to /Users/david/workspace/pstor-compute/server/target/scala-2.13/classes ...
[info] Compiling 5 Scala sources to /Users/david/workspace/pstor-compute/index-builder/target/scala-2.13/classes ...
[error] 'nowarn' is not a valid choice for '-Wunused'
[error] 'nowarn' is not a valid choice for '-Wunused'
```

So here's a PR to remove `nowarn` for 2.13 and introduce explicits to address https://github.com/DavidGregory084/sbt-tpolecat/issues/18

Thanks for the plugin