### PR TITLE
Fix patch version logic

### DIFF
--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -133,7 +133,7 @@ object TpolecatPlugin extends AutoPlugin {
           allScalacOptions
             .filter(validFor(V3_0_0)) // treat dotty prereleases as 3.0.0
             .map(_.name)
-        case (Some((maj, min)), Array(maj2, min2, patch)) if maj == maj2 && min == min2 =>
+        case (Some((maj, min)), Array(maj2, min2, patch)) if maj.toString == maj2 && min.toString == min2 =>
           allScalacOptions
             .filter(validFor(Version(maj, min, Try(patch.toLong).getOrElse(0))))
             .map(_.name)


### PR DESCRIPTION
Follow-up to #32 to fix a bug where `String`s and `Int`s were being compared in the pattern guard causing the case handling patch versions to never match.