### PR TITLE
Updates to support Scala 2.13.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ scalacOptions.in(Tut) ~= filterConsoleScalacOptions
 
 I can't promise this plugin will work for old minor releases of Scala. It has been tested with:
 
+* 2.13.5
 * 2.13.4
 * 2.13.3
 * 2.12.12

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ developers := List(
 )
 homepage := scmInfo.value.map(_.browseUrl)
 
-crossSbtVersions := Seq("0.13.18", "1.4.1")
+crossSbtVersions := Seq("0.13.18", "1.4.7")
 
 enablePlugins(SbtPlugin)
 
@@ -35,7 +35,7 @@ addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
 
 Compile / headerCreate := { (Compile / headerCreate).triggeredBy(Compile / compile).value }
 
-val munitVersion = "0.7.16"
+val munitVersion = "0.7.22"
 
 libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.2.2" % Test,

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.1
+sbt.version=1.4.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.2.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
 
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.4.31")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -30,6 +30,7 @@ object TpolecatPlugin extends AutoPlugin {
     val V2_13_0 = Version(2, 13, 0)
     val V2_13_3 = Version(2, 13, 3)
     val V2_13_4 = Version(2, 13, 4)
+    val V2_13_5 = Version(2, 13, 5)
     val V3_0_0  = Version(3, 0, 0)
 
     implicit val versionOrdering: Ordering[Version] =

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -3,7 +3,8 @@ val scala2Versions = Seq(
   "2.11.12",
   "2.12.12",
   "2.13.3",
-  "2.13.4"
+  "2.13.4",
+  "2.13.5"
 )
 
 crossScalaVersions := (CrossVersion.partialVersion(sbtVersion.value) match {


### PR DESCRIPTION
- Add support for Scala 2.13.5
- Update SBT to 1.4.7
- Update MUnit to 0.7.22
- Update SBT Header to 5.6.0
- Update SBT CI Release 1.5.5

Thank you so much for your work on this plugin!