### PR TITLE
Update project for Scala 3.0.0 and Scala 2.13.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ scalacOptions.in(Tut) ~= filterConsoleScalacOptions
 
 I can't promise this plugin will work for old minor releases of Scala. It has been tested with:
 
+* 2.13.6
 * 2.13.5
 * 2.13.4
 * 2.13.3
@@ -40,9 +41,8 @@ I can't promise this plugin will work for old minor releases of Scala. It has be
 
 and Dotty versions:
 
-* 3.0.0-M1
-* 0.27.0-RC1
-* 0.26.0
+* 3.0.0
+* 3.0.0-RC3
 
 ### License
 

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ developers := List(
 )
 homepage := scmInfo.value.map(_.browseUrl)
 
-crossSbtVersions := Seq("0.13.18", "1.4.7")
+crossSbtVersions := Seq("1.4.9")
 
 enablePlugins(SbtPlugin)
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.7
+sbt.version=1.5.2

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -114,7 +114,7 @@ object TpolecatPlugin extends AutoPlugin {
     ScalacOption("-Wvalue-discard", addedIn = Some(V2_13_0), removedIn = Some(V3_0_0)),                   // ^ Replaces the above
     ScalacOption("-Ykind-projector", addedIn = Some(V3_0_0)),                                             // Enables a subset of kind-projector syntax (see https://github.com/lampepfl/dotty/pull/7775)
     ScalacOption("-Vimplicits", addedIn = Some(V2_13_6), removedIn = Some(V3_0_0)),                       // Enables the tek/splain features to make the compiler print implicit resolution chains when no implicit value can be found
-    ScalacOption("-Vtype-diffs", addedIn = Some(V2_13_6), removedIn = Some(V3_0_0)),                      // Enables the tek/splain features to turn type error messages (found: X, required: Y) into colored diffs between the two types
+    ScalacOption("-Vtype-diffs", addedIn = Some(V2_13_6), removedIn = Some(V3_0_0))                       // Enables the tek/splain features to turn type error messages (found: X, required: Y) into colored diffs between the two types
   )
 
   object autoImport {
@@ -167,7 +167,7 @@ object TpolecatPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Setting[_]] = Seq(
     scalacOptions ++= scalacOptionsFor(scalaVersion.value),
-    scalacOptions.in(Compile, console) ~= filterConsoleScalacOptions,
-    scalacOptions.in(Test, console) ~= filterConsoleScalacOptions
+    Compile / console / scalacOptions ~= filterConsoleScalacOptions,
+    Test /  console / scalacOptions ~= filterConsoleScalacOptions
   )
 }

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -31,6 +31,7 @@ object TpolecatPlugin extends AutoPlugin {
     val V2_13_3 = Version(2, 13, 3)
     val V2_13_4 = Version(2, 13, 4)
     val V2_13_5 = Version(2, 13, 5)
+    val V2_13_6 = Version(2, 13, 6)
     val V3_0_0  = Version(3, 0, 0)
 
     implicit val versionOrdering: Ordering[Version] =
@@ -111,7 +112,9 @@ object TpolecatPlugin extends AutoPlugin {
     ScalacOption("-Wunused:privates", addedIn = Some(V2_13_0), removedIn = Some(V3_0_0)),                 // ^ Replaces the above
     ScalacOption("-Ywarn-value-discard", removedIn = Some(V2_13_0)),                                      // Warn when non-Unit expression results are unused.
     ScalacOption("-Wvalue-discard", addedIn = Some(V2_13_0), removedIn = Some(V3_0_0)),                   // ^ Replaces the above
-    ScalacOption("-Ykind-projector", addedIn = Some(V3_0_0))                                              // Enables a subset of kind-projector syntax (see https://github.com/lampepfl/dotty/pull/7775)
+    ScalacOption("-Ykind-projector", addedIn = Some(V3_0_0)),                                             // Enables a subset of kind-projector syntax (see https://github.com/lampepfl/dotty/pull/7775)
+    ScalacOption("-Vimplicits", addedIn = Some(V2_13_6), removedIn = Some(V3_0_0)),                       // Enables the tek/splain features to make the compiler print implicit resolution chains when no implicit value can be found
+    ScalacOption("-Vtype-diffs", addedIn = Some(V2_13_6), removedIn = Some(V3_0_0)),                      // Enables the tek/splain features to turn type error messages (found: X, required: Y) into colored diffs between the two types
   )
 
   object autoImport {

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -37,7 +37,9 @@ crossScalaVersions := {
     (major, minor, patch) match {
       case (1, 5, z) if z >= 2 => true
       case (x, y, _) if x == 1 && y > 5 => true
-      case (x, _, _) if x > 1 => true
+      case (1, 5, patch) if patch >= 2 => true
+      case (1, minor, _) if minor > 5 => true
+      case (major, _, _) if major > 1 => true
       case _ => false
     }
 

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -1,3 +1,5 @@
+import scala.util.Try
+
 val scala2Versions = Seq(
   "2.10.7",
   "2.11.12",
@@ -13,7 +15,37 @@ val scala3Versions = Seq(
   "3.0.0"
 )
 
-crossScalaVersions := (CrossVersion.sbtApiVersion(sbtVersion.value) match {
-  case Some((1, 5)) => scala2Versions ++ scala3Versions
-  case _ => scala2Versions
-})
+crossScalaVersions := {
+  object ExtractVersion {
+    val sbtVersionMatch = raw"(\d+)\.(\d+)\.(\d+)".r
+    def unapply(sbtVersion: String): Option[(Long, Long, Long)] = {
+      sbtVersion match {
+        case sbtVersionMatch(major, minor, patch) =>
+          for {
+            maj <- Try(major.toLong).toOption
+            min <- Try(minor.toLong).toOption
+            p <- Try(patch.toLong).toOption
+          } yield (maj, min, p)
+
+        case _ =>
+          None
+      }
+    }
+  }
+
+  def supportedSbtVersions(major: Long, minor: Long, patch: Long): Boolean =
+    (major, minor, patch) match {
+      case (1, 5, z) if z >= 2 => true
+      case (x, y, _) if x == 1 && y > 5 => true
+      case (x, _, _) if x > 1 => true
+      case _ => false
+    }
+
+  sbtVersion.value match {
+    case ExtractVersion(major, minor, patch) if supportedSbtVersions(major, minor, patch) =>
+      scala2Versions ++ scala3Versions
+
+    case _ =>
+      scala2Versions
+  }
+}

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -4,10 +4,16 @@ val scala2Versions = Seq(
   "2.12.12",
   "2.13.3",
   "2.13.4",
-  "2.13.5"
+  "2.13.5",
+  "2.13.6"
 )
 
-crossScalaVersions := (CrossVersion.partialVersion(sbtVersion.value) match {
-  case Some((1, _)) => scala2Versions :+ "0.26.0" :+ "0.27.0-RC1" :+ "3.0.0-M1" // the dotty plugin isn't available for sbt 0.13.x, so we can only add the dotty version here
+val scala3Versions = Seq(
+  "3.0.0-RC3",
+  "3.0.0"
+)
+
+crossScalaVersions := (CrossVersion.sbtApiVersion(sbtVersion.value) match {
+  case Some((1, 5)) => scala2Versions ++ scala3Versions
   case _ => scala2Versions
 })

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -35,8 +35,6 @@ crossScalaVersions := {
 
   def supportedSbtVersions(major: Long, minor: Long, patch: Long): Boolean =
     (major, minor, patch) match {
-      case (1, 5, z) if z >= 2 => true
-      case (x, y, _) if x == 1 && y > 5 => true
       case (1, 5, patch) if patch >= 2 => true
       case (1, minor, _) if minor > 5 => true
       case (major, _, _) if major > 1 => true

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/project/plugins.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/project/plugins.sbt
@@ -1,10 +1,1 @@
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % System.getProperty("plugin.version"))
-
-libraryDependencies ++= {
-  CrossVersion.partialVersion(sbtVersion.value) match {
-    case Some((1, _)) => // the dotty plugin isn't available for sbt 0.13.x
-      Seq(Defaults.sbtPluginExtra("ch.epfl.lamp" % "sbt-dotty" % "0.4.5", (sbtBinaryVersion in update).value, (scalaBinaryVersion in update).value))
-    case _ =>
-      Seq.empty
-  }
-}


### PR DESCRIPTION
- add -Vimplicits and -Vtype-diffs for Scala 2.13.6
- drop support for very old dotty versions
- drop support for SBT 0.13.x
- No longer require the sbt-dotty plugin

Thanks to @githubmo for helping me deal with the version accuracy