### PR TITLE
Add the relaxedMode & strictMode commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ By default the plugin only applies this filtering to the `console` task in the `
 scalacOptions.in(Tut) ~= filterConsoleScalacOptions
 ```
 
+Additionally, if you need to temporarily disable fatal warnings.
+You can do it by running the `relaxedMode` command.
+Then, you can enable them again by running the `strictMode` command.
+
 ### Caveat
 
 I can't promise this plugin will work for old minor releases of Scala. It has been tested with:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ scalacOptions.in(Tut) ~= filterConsoleScalacOptions
 
 Additionally, if you need to temporarily disable fatal warnings.
 You can do it by running the `relaxedMode` command.
-Then, you can enable them again by running the `strictMode` command.
+Then, you can enable them again by running the `strictMode` command.<br>
+You may also enable the relaxed mode by setting the `SBT_TPOLECAT_RELAXED` env var.
 
 ### Caveat
 

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -163,15 +163,27 @@ object TpolecatPlugin extends AutoPlugin {
     }
 
     lazy val strictMode: Command = Command.command("strictMode") { state =>
-      Project.extract(state).appendWithSession(
-        scalacOptions += "-Xfatal-warnings",
+      val projectRef = Project.extract(state)
+
+      val actions = projectRef.structure.allProjectRefs.map { p =>
+        p / scalacOptions += "-Xfatal-warnings"
+      }
+
+      projectRef.appendWithSession(
+        actions,
         state
       )
     }
 
     lazy val relaxedMode: Command = Command.command("relaxedMode") { state =>
-      Project.extract(state).appendWithSession(
-        scalacOptions -= "-Xfatal-warnings",
+      val projectRef = Project.extract(state)
+
+      val actions = projectRef.structure.allProjectRefs.map { p =>
+        p / scalacOptions -= "-Xfatal-warnings"
+      }
+
+      projectRef.appendWithSession(
+        actions,
         state
       )
     }

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -161,6 +161,20 @@ object TpolecatPlugin extends AutoPlugin {
         "-Xfatal-warnings"
       ))
     }
+
+    lazy val strictMode: Command = Command.command("strictMode") { state =>
+      Project.extract(state).appendWithSession(
+        scalacOptions += "-Xfatal-warnings",
+        state
+      )
+    }
+
+    lazy val relaxedMode: Command = Command.command("relaxedMode") { state =>
+      Project.extract(state).appendWithSession(
+        scalacOptions -= "-Xfatal-warnings",
+        state
+      )
+    }
   }
 
   import autoImport._
@@ -168,6 +182,7 @@ object TpolecatPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = Seq(
     scalacOptions ++= scalacOptionsFor(scalaVersion.value),
     Compile / console / scalacOptions ~= filterConsoleScalacOptions,
-    Test /  console / scalacOptions ~= filterConsoleScalacOptions
+    Test /  console / scalacOptions ~= filterConsoleScalacOptions,
+    commands ++= Seq(strictMode, relaxedMode)
   )
 }


### PR DESCRIPTION
The idea of this PR is to allow users to quickly enable / disable fatal-warnings.

I am open to changing the names of the commands; since I don't think they are clear enough, but I wasn't able to come with better names.
Also, not sure if we should add some tests _(and how should I do it)_.

Finally, maybe it would be good to not hard code it to `-Xfatal-warnings`; but rather retrieve the right one from the current version. WDYT?