### PR TITLE
Various dependency & README updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        java-version: [8, 11]
+        java-version: [8, 11, 17]
 
     steps:
     - name: Checkout

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ It is currently tested with Scala 2.x releases:
 * 2.13.8
 * 2.12.15
 * 2.11.12
-* 2.10.7
 
 and Scala 3.x releases:
 

--- a/README.md
+++ b/README.md
@@ -29,20 +29,23 @@ scalacOptions.in(Tut) ~= filterConsoleScalacOptions
 
 ### Caveat
 
-I can't promise this plugin will work for old minor releases of Scala. It has been tested with:
+I can't promise this plugin will work for old minor releases of Scala.
 
-* 2.13.6
-* 2.13.5
-* 2.13.4
-* 2.13.3
-* 2.12.12
+It is currently tested with Scala 2.x releases:
+
+* 2.13.8
+* 2.12.15
 * 2.11.12
 * 2.10.7
 
-and Dotty versions:
+and Scala 3.x releases:
 
-* 3.0.0
-* 3.0.0-RC3
+* 3.0.2
+* 3.1.1
+
+### Conduct
+
+Participants are expected to follow the [Scala Code of Conduct](https://www.scala-lang.org/conduct/) while discussing the project on GitHub and any other venues associated with the project.
 
 ### License
 

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ description := "scalac options for the enlightened"
 organization := "io.github.davidgregory084"
 
 organizationName := "David Gregory"
-startYear := Some(2019)
+startYear := Some(2022)
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 scmInfo := Some(
   ScmInfo(
@@ -23,7 +23,7 @@ developers := List(
 )
 homepage := scmInfo.value.map(_.browseUrl)
 
-crossSbtVersions := Seq("1.4.9")
+crossSbtVersions := Seq("1.6.2")
 
 enablePlugins(SbtPlugin)
 
@@ -34,13 +34,12 @@ addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
 // License headers
 
 Compile / headerCreate := { (Compile / headerCreate).triggeredBy(Compile / compile).value }
-
-val munitVersion = "0.7.22"
+Test / headerCreate := { (Test / headerCreate).triggeredBy(Test / compile).value }
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.2" % Test,
-  "org.scalacheck" %% "scalacheck" % "1.14.1" % Test,
-  "org.scalatestplus" %% "scalacheck-1-14" % "3.2.2.0" % Test
+  "org.scalatest" %% "scalatest" % "3.2.11" % Test,
+  "org.scalacheck" %% "scalacheck" % "1.15.4" % Test,
+  "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test
 )
 
 // Testing

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.2
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,5 @@
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.5")
 
-addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.5")
+addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
+
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.2")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.2")

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 David Gregory
+ * Copyright 2022 David Gregory
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -3,16 +3,13 @@ import scala.util.Try
 val scala2Versions = Seq(
   "2.10.7",
   "2.11.12",
-  "2.12.12",
-  "2.13.3",
-  "2.13.4",
-  "2.13.5",
-  "2.13.6"
+  "2.12.15",
+  "2.13.8"
 )
 
 val scala3Versions = Seq(
-  "3.0.0-RC3",
-  "3.0.0"
+  "3.0.2",
+  "3.1.1"
 )
 
 crossScalaVersions := {

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -1,7 +1,6 @@
 import scala.util.Try
 
 val scala2Versions = Seq(
-  "2.10.7",
   "2.11.12",
   "2.12.15",
   "2.13.8"

--- a/src/test/scala/io/github/davidgregory084/TpolecatPluginSuite.scala
+++ b/src/test/scala/io/github/davidgregory084/TpolecatPluginSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 David Gregory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.github.davidgregory084
 
 import org.scalatest.funsuite.AnyFunSuite


### PR DESCRIPTION
This updates a few different things:

* Drops 2.10.x support - it appears that 2.10.x cannot be used with Java 17
* Drops old minor releases for each major 2.x release from scripted testing
* Adds Scala 3.1.x to scripted testing
* Adds Java 17 (the new LTS) to the build matrix
* Clarifies that the Scala Code of Conduct applies here
* Updates various test & sbt plugin dependencies which have seen new releases