### PR TITLE
Add dev, CI, release mode functionality to the plugin

### DIFF
--- a/.scalafix.conf
+++ b/.scalafix.conf
@@ -1,0 +1,7 @@
+rules = [
+    OrganizeImports
+]
+
+OrganizeImports {
+  preset = INTELLIJ_2020_3
+}

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,13 @@
+version = 3.4.3
+
+runner.dialect = scala212
+
+preset = defaultWithAlign
+
+maxColumn = 100
+
+indent {
+  callSite = 2
+  defnSite = 2
+  extendSite = 2
+}

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ tpolecatReleaseModeOptions ++= ScalacOptions.optimizerOptions("your.library.**")
 
 To understand more about the Scala optimizer read [The Scala 2.12 / 2.13 Inliner and Optimizer](https://docs.scala-lang.org/overviews/compiler-options/optimizer.html).
 
-You can customise the environment variable that is used to enable this mode by modifying the `ThisBuild / tpolecatReleaseModeEnvVar` key. Default: `"SBT_TPOLECAT_RELEASE`.
+You can customise the environment variable that is used to enable this mode by modifying the `ThisBuild / tpolecatReleaseModeEnvVar` key. Default: `"SBT_TPOLECAT_RELEASE"`.
 
 ### Caveat
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Modes can selected by using mode switching commands, or by setting environment v
 
 When multiple mode-setting environment variables are defined, the most restrictive mode is selected. For example, if the `SBT_TPOLECAT_DEV` and `SBT_TPOLECAT_CI` variables are both defined, continuous integration mode will be enabled.
 
-You can customise the default mode by modifying the `ThisBuild / tpolecatDefaultMode` key. Default: `CiMode`.
+You can customise the default mode by modifying the `ThisBuild / tpolecatDefaultOptionsMode` key. Default: `CiMode`.
 
 #### Development mode
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,82 @@ Add the following to your project's `project/plugins.sbt`:
 addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.22")
 ```
 
-If necessary you can filter out scalac options that are unhelpful in the REPL from user-defined tasks or scopes.
+To filter out scala compiler options that don't work well in the REPL, use the `tpolecatConsoleOptionsFilter`.
 
-By default the plugin only applies this filtering to the `console` task in the `Compile` and `Test` configurations.
+By default the plugin only applies this filter to the `console` task in the `Compile` and `Test` configurations.
+
+For example, to apply this filter to the `console` task in the `IntegrationTest` configuration you can do the following:
 
 ```scala
-scalacOptions.in(Tut) ~= filterConsoleScalacOptions
+IntegrationTest / console / tpolecatScalacOptions ~= tpolecatConsoleOptionsFilter
 ```
+
+### Modes
+
+This plugin can be used in several modes. The default mode is the continous integration mode.
+
+Modes can selected by using mode switching commands, or by setting environment variables.
+
+When multiple mode-setting environment variables are defined, the most restrictive mode is selected. For example, if the `SBT_TPOLECAT_DEV` and `SBT_TPOLECAT_CI` variables are both defined, continuous integration mode will be enabled.
+
+You can customise the default mode by modifying the `ThisBuild / tpolecatDefaultMode` key. Default: `CiMode`.
+
+#### Development mode
+
+To enable the development mode, use the `tpolecatDevMode` command or define the environment variable `SBT_TPOLECAT_DEV`.
+
+In this mode a baseline set of scala compiler options are enabled.
+
+You can customise the options that are enabled in this mode by modifying the `tpolecatDevModeOptions` key. Default: `ScalacOptions.default`.
+
+For example, to disable macros you could customise the development mode options as follows:
+
+```scala
+tpolecatDevModeOptions ~= { opts =>
+  opts.filterNot(Set(ScalacOptions.languageExperimentalMacros))
+}
+```
+
+You can customise the environment variable that is used to enable this mode by modifying the `ThisBuild / tpolecatDevModeEnvVar` key. Default: `"SBT_TPOLECAT_DEV"`.
+
+#### Continuous integration mode
+
+To enable the continuous integration mode, use the `tpolecatCiMode` command or define the environment variable `SBT_TPOLECAT_CI`.
+
+In this mode all development mode options are enabled, and the fatal warning options (`-Xfatal-warnings` / `-Werror`) are added as appropriate for your Scala version.
+
+You can customise the options that are enabled in this mode by modifying the `tpolecatCiModeOptions` key. Default: `tpolecatDevModeOptions.value ++ ScalacOptions.fatalWarningOptions`.
+
+For example, to disable unused linting you could customise the CI options as follows:
+
+```scala
+tpolecatCiModeOptions ~= { opts =>
+  opts.filterNot(
+    ScalacOptions.privateWarnUnusedOptions ++
+      ScalacOptions.warnUnusedOptions
+  )
+}
+```
+
+You can customise the environment variable that is used to enable this mode by modifying the `ThisBuild / tpolecatCiModeEnvVar` key. Default: `"SBT_TPOLECAT_CI"`.
+
+#### Release mode
+
+To enable the release mode, use the `tpolecatReleaseMode` command or define the environment variable `SBT_TPOLECAT_RELEASE`.
+
+In this mode all CI mode options are enabled, and the method-local optimisation option (`-opt:l:method`) is enabled if available for your Scala version.
+
+You can customise the options that are enabled in this mode by modifying the `tpolecatReleaseModeOptions` key. Default: `tpolecatCiModeOptions.value + ScalacOptions.optimizerMethodLocal`.
+
+For example, to enable inlining within your library or application's packages you could customise the release options as follows:
+
+```scala
+tpolecatReleaseModeOptions ++= ScalacOptions.optimizerOptions("your.library.**")
+```
+
+To understand more about the Scala optimizer read [The Scala 2.12 / 2.13 Inliner and Optimizer](https://docs.scala-lang.org/overviews/compiler-options/optimizer.html).
+
+You can customise the environment variable that is used to enable this mode by modifying the `ThisBuild / tpolecatReleaseModeEnvVar` key. Default: `"SBT_TPOLECAT_RELEASE`.
 
 ### Caveat
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,11 @@
 // Common settings
 
-name := "sbt-tpolecat"
-description := "scalac options for the enlightened"
+name         := "sbt-tpolecat"
+description  := "scalac options for the enlightened"
 organization := "io.github.davidgregory084"
 
 organizationName := "David Gregory"
-startYear := Some(2022)
+startYear        := Some(2022)
 licenses += ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0.html"))
 scmInfo := Some(
   ScmInfo(
@@ -34,20 +34,27 @@ addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
 // License headers
 
 Compile / headerCreate := { (Compile / headerCreate).triggeredBy(Compile / compile).value }
-Test / headerCreate := { (Test / headerCreate).triggeredBy(Test / compile).value }
+Test / headerCreate    := { (Test / headerCreate).triggeredBy(Test / compile).value }
+
+scalacOptions += "-Xlint:unused"
 
 libraryDependencies ++= Seq(
-  "org.scalatest" %% "scalatest" % "3.2.11" % Test,
-  "org.scalacheck" %% "scalacheck" % "1.15.4" % Test,
+  "org.scalatest"     %% "scalatest"       % "3.2.11"   % Test,
+  "org.scalacheck"    %% "scalacheck"      % "1.15.4"   % Test,
   "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % Test
 )
+
+ThisBuild / semanticdbEnabled                              := true
+ThisBuild / semanticdbVersion                              := scalafixSemanticdb.revision
+ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
 
 // Testing
 
 scriptedBufferLog := false
 
 scriptedLaunchOpts := scriptedLaunchOpts.value ++ Seq(
-  "-Xmx1024M", "-Dplugin.version=" + version.value
+  "-Xmx1024M",
+  "-Dplugin.version=" + version.value
 )
 
 test := {

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,3 +3,7 @@ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.6.5")
 addSbtPlugin("com.geirsson" % "sbt-ci-release" % "1.5.7")
 
 addSbtPlugin("com.timushev.sbt" % "sbt-updates" % "0.6.2")
+
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.6")
+
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.34")

--- a/src/main/scala/io/github/davidgregory084/OptionsMode.scala
+++ b/src/main/scala/io/github/davidgregory084/OptionsMode.scala
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2022 David Gregory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.davidgregory084
+
+sealed abstract class OptionsMode extends Product with Serializable
+
+case object DevMode     extends OptionsMode
+case object CiMode      extends OptionsMode
+case object ReleaseMode extends OptionsMode

--- a/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2022 David Gregory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.davidgregory084
+
+import scala.Ordering.Implicits._
+
+case class ScalaVersion(major: Long, minor: Long, patch: Long) {
+  def isBetween(addedVersion: ScalaVersion, removedVersion: ScalaVersion) =
+    this >= addedVersion && this < removedVersion
+}
+
+object ScalaVersion {
+  val V2_11_0 = ScalaVersion(2, 11, 0)
+  val V2_12_0 = ScalaVersion(2, 12, 0)
+  val V2_13_0 = ScalaVersion(2, 13, 0)
+  val V2_13_3 = ScalaVersion(2, 13, 3)
+  val V2_13_4 = ScalaVersion(2, 13, 4)
+  val V2_13_5 = ScalaVersion(2, 13, 5)
+  val V2_13_6 = ScalaVersion(2, 13, 6)
+  val V3_0_0  = ScalaVersion(3, 0, 0)
+
+  implicit val scalaVersionOrdering: Ordering[ScalaVersion] =
+    Ordering.by(version => (version.major, version.minor, version.patch))
+}

--- a/src/main/scala/io/github/davidgregory084/ScalacOption.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOption.scala
@@ -19,4 +19,15 @@ package io.github.davidgregory084
 case class ScalacOption(
   tokens: List[String],
   isSupported: ScalaVersion => Boolean = _ => true
-)
+) {
+  // We don't want to use `isSupported` in hashCode
+  override def hashCode(): Int =
+    41 * tokens.hashCode
+
+  // We don't want to compare `isSupported` for equality
+  override def equals(other: Any): Boolean =
+    other match {
+      case that: ScalacOption => this.tokens == that.tokens
+      case _                  => false
+    }
+}

--- a/src/main/scala/io/github/davidgregory084/ScalacOption.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOption.scala
@@ -16,15 +16,21 @@
 
 package io.github.davidgregory084
 
-case class ScalacOption(
-  tokens: List[String],
-  isSupported: ScalaVersion => Boolean = _ => true
+/** A Scala compiler option.
+  *
+  * @param tokens
+  *   The tokens which must be provided to declare this option.
+  * @param isSupported
+  *   A predicate function determining whether the provided Scala compiler version supports this
+  *   option.
+  */
+class ScalacOption(
+  val tokens: List[String],
+  val isSupported: ScalaVersion => Boolean = _ => true
 ) {
-  // We don't want to use `isSupported` in hashCode
   override def hashCode(): Int =
     41 * tokens.hashCode
 
-  // We don't want to compare `isSupported` for equality
   override def equals(other: Any): Boolean =
     other match {
       case that: ScalacOption => this.tokens == that.tokens

--- a/src/main/scala/io/github/davidgregory084/ScalacOption.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOption.scala
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2022 David Gregory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.davidgregory084
+
+case class ScalacOption(
+  tokens: List[String],
+  isSupported: ScalaVersion => Boolean = _ => true
+)

--- a/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -48,7 +48,7 @@ trait ScalacOptions {
     List("-language:implicitConversions")
   )
 
-  val languageFeatures: Set[ScalacOption] = ListSet(
+  val languageFeatureOptions: Set[ScalacOption] = ListSet(
     languageExistentials,
     languageExperimentalMacros,
     languageHigherKinds,
@@ -330,7 +330,7 @@ trait ScalacOptions {
     deprecation,
     feature,
     unchecked
-  ) ++ languageFeatures ++ advancedOptions ++ privateOptions ++ warnOptions
+  ) ++ languageFeatureOptions ++ advancedOptions ++ privateOptions ++ warnOptions
 
   def optimizerOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
     ScalacOption(List(s"-opt$name"), isSupported)

--- a/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -22,32 +22,53 @@ import scala.collection.immutable.ListSet
 trait ScalacOptions {
   import ScalaVersion._
 
-  def encoding(enc: String) = ScalacOption(List("-encoding", enc))
+  /** Specify character encoding used by source files.
+    */
+  def encoding(enc: String) =
+    new ScalacOption(List("-encoding", enc))
 
-  val deprecation = ScalacOption(
+  /** Emit warning and location for usages of deprecated APIs.
+    */
+  val deprecation = new ScalacOption(
     List("-deprecation"),
     version => version < V2_13_0 || version >= V3_0_0
   )
 
-  val feature = ScalacOption(List("-feature"))
+  /** Emit warning and location for usages of features that should be imported explicitly.
+    */
+  val feature =
+    new ScalacOption(List("-feature"))
 
-  val languageExistentials = ScalacOption(
-    List("-language:existentials"),
-    version => version < V3_0_0
-  )
+  /** Enable or disable language features
+    */
+  def languageFeatureOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
+    new ScalacOption(
+      List(s"-language:$name"),
+      isSupported
+    )
 
-  val languageExperimentalMacros = ScalacOption(
-    List("-language:experimental.macros")
-  )
+  /** Existential types (besides wildcard types) can be written and inferred.
+    */
+  val languageExistentials =
+    languageFeatureOption("existentials", version => version < V3_0_0)
 
-  val languageHigherKinds = ScalacOption(
-    List("-language:higherKinds")
-  )
+  /** Allow macro definition (besides implementation and application).
+    */
+  val languageExperimentalMacros =
+    languageFeatureOption("experimental.macros")
 
-  val languageImplicitConversions = ScalacOption(
-    List("-language:implicitConversions")
-  )
+  /** Allow higher-kinded types.
+    */
+  val languageHigherKinds =
+    languageFeatureOption("higherKinds")
 
+  /** Allow definition of implicit functions called views.
+    */
+  val languageImplicitConversions =
+    languageFeatureOption("implicitConversions")
+
+  /** Preferred language feature options.
+    */
   val languageFeatureOptions: Set[ScalacOption] = ListSet(
     languageExistentials,
     languageExperimentalMacros,
@@ -55,92 +76,162 @@ trait ScalacOptions {
     languageImplicitConversions
   )
 
-  val unchecked = ScalacOption(List("-unchecked"))
+  /** Enable additional warnings where generated code depends on assumptions.
+    */
+  val unchecked =
+    new ScalacOption(List("-unchecked"))
 
+  /** Advanced options (-X)
+    */
   def advancedOption(name: String, isSupported: ScalaVersion => Boolean = _ => true): ScalacOption =
-    ScalacOption(List(s"-X$name"), isSupported)
+    new ScalacOption(List(s"-X$name"), isSupported)
 
+  /** Wrap field accessors to throw an exception on uninitialized access.
+    */
   val checkInit =
     advancedOption("checkinit", version => version < V3_0_0)
 
+  /** Fail the compilation if there are any warnings.
+    */
   val fatalWarnings =
     advancedOption("fatal-warnings", version => version < V2_13_0 || version >= V3_0_0)
 
+  /** Enable recommended warnings.
+    */
   val lint =
     advancedOption("lint", version => version < V2_11_0)
 
+  /** Enable recommended warnings.
+    */
   def lintOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
     advancedOption(s"lint:$name", isSupported)
 
+  /** Disable recommended warnings.
+    */
   def disableLintOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
     advancedOption(s"lint:-$name", isSupported)
 
+  /** Warn if an argument list is modified to match the receiver.
+    */
   val lintAdaptedArgs =
     lintOption("adapted-args", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn if a right-associative operator taking a by-name parameter is used.
+    *
+    * The bug which necessitated this lint was fixed in Scala 2.13.
+    *
+    * See: [[https://github.com/scala/scala/pull/5969 scala/scala#5969]],
+    * [[https://docs.scala-lang.org/sips/right-associative-by-name-operators.html SIP-34]]
+    */
   val lintByNameRightAssociative =
     lintOption("by-name-right-associative", version => version.isBetween(V2_11_0, V2_13_0))
 
+  /** Warn if evaluation of a constant arithmetic expression results in an error.
+    */
   val lintConstant =
     lintOption("constant", version => version.isBetween(V2_12_0, V3_0_0))
 
+  /** Warn when selecting a member of DelayedInit.
+    */
   val lintDelayedInitSelect =
     lintOption("delayedinit-select", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Enable linted deprecations.
+    */
   val lintDeprecation =
     lintOption("deprecation", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn when a Scaladoc comment appears to be detached from its element.
+    */
   val lintDocDetached =
     lintOption("doc-detached", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when an implicit resolves to an enclosing self-definition.
+    */
   val lintImplicitRecursion =
     lintOption("implicit-recursion", version => version.isBetween(V2_13_3, V3_0_0))
 
+  /** Warn when an @implicitNotFound or @implicitAmbigous annotation references an invalid type
+    * parameter.
+    */
   val lintImplicitNotFound =
     lintOption("implicit-not-found", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn about inaccessible types in method signatures.
+    */
   val lintInaccessible =
     lintOption("inaccessible", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when a type argument is inferred to be Any.
+    */
   val lintInferAny =
     lintOption("infer-any", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when a string literal appears to be missing an interpolator id.
+    */
   val lintMissingInterpolator =
     lintOption("missing-interpolator", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when non-nullary def f() overrides nullary def f.
+    */
   val lintNullaryOverride =
     lintOption("nullary-override", version => version.isBetween(V2_11_0, V2_13_0))
 
+  /** Warn when nullary methods return Unit.
+    */
   val lintNullaryUnit =
     lintOption("nullary-unit", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when Option.apply uses an implicit view.
+    */
   val lintOptionImplicit =
     lintOption("option-implicit", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when a class or object is defined in a package object.
+    */
   val lintPackageObjectClasses =
     lintOption("package-object-classes", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when a parameterized overloaded implicit methods is used in a view bound.
+    */
   val lintPolyImplicitOverload =
     lintOption("poly-implicit-overload", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when a private field (or class parameter) shadows a superclass field.
+    */
   val lintPrivateShadow =
     lintOption("private-shadow", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when a pattern sequence wildcard does not align with the sequence component of the data
+    * being matched.
+    */
   val lintStarsAlign =
     lintOption("stars-align", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when matching on an unsealed class without a catch-all patttern.
+    */
   val lintStrictUnsealedPatmat =
     lintOption("strict-unsealed-patmat", version => version.isBetween(V2_13_4, V3_0_0))
 
+  /** Warn when a local type parameter shadows a type already in scope.
+    */
   val lintTypeParameterShadow =
     lintOption("type-parameter-shadow", version => version.isBetween(V2_11_0, V3_0_0))
 
+  /** Warn when a pattern matches using `.equals` and therefore may be unsound.
+    */
   val lintUnsoundMatch =
     lintOption("unsound-match", version => version.isBetween(V2_11_0, V2_13_0))
 
+  /** Warn when a by-name implicit conversion is applied to the result of a block.
+    *
+    * We disable this lint because it is triggered by Shapeless' Lazy encoding.
+    */
   val disableLintBynameImplicit =
     disableLintOption("byname-implicit", version => version.isBetween(V2_13_3, V3_0_0))
 
+  /** Advanced linting options (-Xlint:)
+    */
   val lintOptions: Set[ScalacOption] = ListSet(
     lintAdaptedArgs,
     lintByNameRightAssociative,
@@ -166,71 +257,116 @@ trait ScalacOptions {
     disableLintBynameImplicit
   )
 
+  /** Advanced options (-X)
+    */
   val advancedOptions: Set[ScalacOption] = ListSet(
     checkInit,
     lint
   ) ++ lintOptions
 
+  /** Private options (-Y)
+    */
   def privateOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
-    ScalacOption(List(s"-Y$name"), isSupported)
+    new ScalacOption(List(s"-Y$name"), isSupported)
 
+  /** Produce an error if an argument list is modified to match the receiver.
+    */
   val privateNoAdaptedArgs =
     privateOption("no-adapted-args", version => version < V2_13_0)
 
+  /** Enables support for a subset of [[https://github.com/typelevel/kind-projector kind-projector]]
+    * syntax.
+    */
   val privateKindProjector =
     privateOption("kind-projector", version => version >= V3_0_0)
 
+  /** Private warning options (-Ywarn)
+    */
   def privateWarnOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
     privateOption(s"warn-$name", isSupported)
 
+  /** Warn when dead code is identified.
+    */
   val privateWarnDeadCode =
     privateWarnOption("dead-code", version => version < V2_13_0)
 
+  /** Warn when more than one implicit parameter section is defined.
+    */
   val privateWarnExtraImplicit =
     privateWarnOption("extra-implicit", version => version.isBetween(V2_12_0, V2_13_0))
 
+  /** Warn about inaccessible types in method signatures.
+    */
   val privateWarnInaccessible =
     privateWarnOption("inaccessible", version => version < V2_11_0)
 
+  /** Warn when non-nullary def f() overrides nullary def f.
+    */
   val privateWarnNullaryOverride =
     privateWarnOption("nullary-override", version => version < V2_13_0)
 
+  /** Warn when nullary methods return Unit.
+    */
   val privateWarnNullaryUnit =
     privateWarnOption("nullary-unit", version => version < V2_13_0)
 
+  /** Warn when numerics are widened.
+    */
   val privateWarnNumericWiden =
     privateWarnOption("numeric-widen", version => version < V2_13_0)
 
+  /** Warn when local and private vals, vars, defs and types are unused.
+    */
   val privateWarnUnused =
     privateWarnOption("unused", version => version.isBetween(V2_11_0, V2_12_0))
 
+  /** Warn if an import selector is not referenced.
+    */
   val privateWarnUnusedImport =
     privateWarnOption("unused-import", version => version.isBetween(V2_11_0, V2_12_0))
 
+  /** Warn when non-Unit expression results are unused.
+    */
   val privateWarnValueDiscard =
     privateWarnOption("value-discard", version => version < V2_13_0)
 
+  /** Private unused warning options (-Ywarn-unused:)
+    */
   def privateWarnUnusedOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
     privateWarnOption(s"unused:$name", isSupported)
 
+  /** Warn if an implicit parameter is unused.
+    */
   val privateWarnUnusedImplicits =
     privateWarnUnusedOption("implicits", version => version.isBetween(V2_12_0, V2_13_0))
 
+  /** Warn if an import selector is not referenced.
+    */
   val privateWarnUnusedImports =
     privateWarnUnusedOption("imports", version => version.isBetween(V2_12_0, V2_13_0))
 
+  /** Warn if a local definition is unused.
+    */
   val privateWarnUnusedLocals =
     privateWarnUnusedOption("locals", version => version.isBetween(V2_12_0, V2_13_0))
 
+  /** Warn if an explicit parameter is unused.
+    */
   val privateWarnUnusedParams =
     privateWarnUnusedOption("params", version => version.isBetween(V2_12_0, V2_13_0))
 
+  /** Warn if a variable bound in a pattern is unused.
+    */
   val privateWarnUnusedPatVars =
     privateWarnUnusedOption("patvars", version => version.isBetween(V2_12_0, V2_13_0))
 
+  /** Warn if a private member is unused.
+    */
   val privateWarnUnusedPrivates =
     privateWarnUnusedOption("privates", version => version.isBetween(V2_12_0, V2_13_0))
 
+  /** Private unused warning options (-Ywarn-unused:)
+    */
   val privateWarnUnusedOptions: Set[ScalacOption] = ListSet(
     privateWarnUnusedImplicits,
     privateWarnUnusedImports,
@@ -240,6 +376,8 @@ trait ScalacOptions {
     privateWarnUnusedPrivates
   )
 
+  /** Private warning options (-Ywarn)
+    */
   val privateWarnOptions: Set[ScalacOption] = ListSet(
     privateWarnDeadCode,
     privateWarnExtraImplicit,
@@ -252,56 +390,92 @@ trait ScalacOptions {
     privateWarnValueDiscard
   ) ++ privateWarnUnusedOptions
 
+  /** Private options (-Y)
+    */
   val privateOptions: Set[ScalacOption] = ListSet(
     privateNoAdaptedArgs,
     privateKindProjector
   ) ++ privateWarnOptions
 
+  /** Warning options (-W)
+    */
   def warnOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
-    ScalacOption(List(s"-W$name"), isSupported)
+    new ScalacOption(List(s"-W$name"), isSupported)
 
+  /** Warn when dead code is identified.
+    */
   val warnDeadCode =
     warnOption("dead-code", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn when more than one implicit parameter section is defined.
+    */
   val warnExtraImplicit =
     warnOption("extra-implicit", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn when numerics are widened.
+    */
   val warnNumericWiden =
     warnOption("numeric-widen", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn when non-Unit expression results are unused.
+    */
   val warnValueDiscard =
     warnOption("value-discard", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Fail the compilation if there are any warnings.
+    */
   val warnError =
     warnOption("error", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Unused warning options (-Wunused:)
+    */
   def warnUnusedOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
-    ScalacOption(List(s"-Wunused:$name"), isSupported)
+    new ScalacOption(List(s"-Wunused:$name"), isSupported)
 
+  /** Warn if a @nowarn annotation did not suppress at least one warning.
+    */
   val warnUnusedNoWarn =
     warnUnusedOption("nowarn", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn if an implicit parameter is unused.
+    */
   val warnUnusedImplicits =
     warnUnusedOption("implicits", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn if an explicit parameter is unused.
+    */
   val warnUnusedExplicits =
     warnUnusedOption("explicits", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn if an import selector is not referenced.
+    */
   val warnUnusedImports =
     warnUnusedOption("imports", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn if a local definition is unused.
+    */
   val warnUnusedLocals =
     warnUnusedOption("locals", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn if either explicit or implicit parameters are unused.
+    *
+    * Equivalent to -Wunused:explicits,implicits.
+    */
   val warnUnusedParams =
     warnUnusedOption("params", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn if a variable bound in a pattern is unused.
+    */
   val warnUnusedPatVars =
     warnUnusedOption("patvars", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Warn if a private member is unused.
+    */
   val warnUnusedPrivates =
     warnUnusedOption("privates", version => version.isBetween(V2_13_0, V3_0_0))
 
+  /** Unused warning options (-Wunused:)
+    */
   val warnUnusedOptions: Set[ScalacOption] = ListSet(
     warnUnusedNoWarn,
     warnUnusedImplicits,
@@ -313,6 +487,8 @@ trait ScalacOptions {
     warnUnusedPrivates
   )
 
+  /** Warning options (-W)
+    */
   val warnOptions: Set[ScalacOption] = ListSet(
     warnDeadCode,
     warnExtraImplicit,
@@ -320,11 +496,15 @@ trait ScalacOptions {
     warnValueDiscard
   ) ++ warnUnusedOptions
 
+  /** Options which fail the compilation if there are any warnings.
+    */
   val fatalWarningOptions: Set[ScalacOption] = ListSet(
     fatalWarnings,
     warnError
   )
 
+  /** The default set of Scala compiler options defined by sbt-tpolecat.
+    */
   val default: Set[ScalacOption] = ListSet(
     encoding("utf8"),
     deprecation,
@@ -332,24 +512,49 @@ trait ScalacOptions {
     unchecked
   ) ++ languageFeatureOptions ++ advancedOptions ++ privateOptions ++ warnOptions
 
+  /** Optimizer options (-opt)
+    */
   def optimizerOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
-    ScalacOption(List(s"-opt$name"), isSupported)
+    new ScalacOption(List(s"-opt$name"), isSupported)
 
+  /** Enable intra-method optimizations:
+    * unreachable-code,simplify-jumps,compact-locals,copy-propagation,redundant-casts,box-unbox,nullness-tracking,closure-invocations,allow-skip-core-module-init,assume-modules-non-null,allow-skip-class-loading.
+    */
   val optimizerMethodLocal =
     optimizerOption(":l:method", version => version.isBetween(V2_12_0, V3_0_0))
 
+  /** Enable cross-method optimizations.
+    *
+    * Note: inlining requires -opt-inline-from and -opt:l:method to be provided.
+    */
   val optimizerInline =
     optimizerOption(":l:inline", version => version.isBetween(V2_12_0, V3_0_0))
 
+  /** Enable optimizer warnings
+    */
   val optimizerWarnings =
     optimizerOption("-warnings", version => version.isBetween(V2_12_0, V3_0_0))
 
+  /** Patterns for classfile names from which to allow inlining.
+    *
+    * @param inlineFromPackages
+    *   Patterns declaring packages and classfiles to inline from.
+    * @return
+    *   [[ScalacOption]] declaring the packages and classfiles to be used for inlining.
+    */
   def optimizerInlineFrom(inlineFromPackages: String*) =
     optimizerOption(
       s"-inline-from:${inlineFromPackages.mkString(":")}",
       version => version.isBetween(V2_12_0, V3_0_0)
     )
 
+  /** Enable cross-method optimizations.
+    *
+    * @param inlineFromPackages
+    *   Patterns declaring packages and classfiles to inline from.
+    * @return
+    *   [[ScalacOption]]s used to enable cross-method optimizations.
+    */
   def optimizerOptions(inlineFromPackages: String*): Set[ScalacOption] = ListSet(
     optimizerMethodLocal,
     optimizerInline,

--- a/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -1,0 +1,358 @@
+/*
+ * Copyright 2022 David Gregory
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.github.davidgregory084
+
+import scala.Ordering.Implicits._
+import scala.collection.immutable.ListSet
+
+trait ScalacOptions {
+  import ScalaVersion._
+
+  def encoding(enc: String) = ScalacOption(List("-encoding", enc))
+
+  val deprecation = ScalacOption(
+    List("-deprecation"),
+    version => version < V2_13_0 || version >= V3_0_0
+  )
+
+  val feature = ScalacOption(List("-feature"))
+
+  val languageExistentials = ScalacOption(
+    List("-language:existentials"),
+    version => version < V3_0_0
+  )
+
+  val languageExperimentalMacros = ScalacOption(
+    List("-language:experimental.macros")
+  )
+
+  val languageHigherKinds = ScalacOption(
+    List("-language:higherKinds")
+  )
+
+  val languageImplicitConversions = ScalacOption(
+    List("-language:implicitConversions")
+  )
+
+  val languageFeatures: Set[ScalacOption] = ListSet(
+    languageExistentials,
+    languageExperimentalMacros,
+    languageHigherKinds,
+    languageImplicitConversions
+  )
+
+  val unchecked = ScalacOption(List("-unchecked"))
+
+  def advancedOption(name: String, isSupported: ScalaVersion => Boolean = _ => true): ScalacOption =
+    ScalacOption(List(s"-X$name"), isSupported)
+
+  val checkInit =
+    advancedOption("checkinit", version => version < V3_0_0)
+
+  val fatalWarnings =
+    advancedOption("fatal-warnings", version => version < V2_13_0 || version >= V3_0_0)
+
+  val lint =
+    advancedOption("lint", version => version < V2_11_0)
+
+  def lintOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
+    advancedOption(s"lint:$name", isSupported)
+
+  def disableLintOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
+    advancedOption(s"lint:-$name", isSupported)
+
+  val lintAdaptedArgs =
+    lintOption("adapted-args", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintByNameRightAssociative =
+    lintOption("by-name-right-associative", version => version.isBetween(V2_11_0, V2_13_0))
+
+  val lintConstant =
+    lintOption("constant", version => version.isBetween(V2_12_0, V3_0_0))
+
+  val lintDelayedInitSelect =
+    lintOption("delayedinit-select", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintDeprecation =
+    lintOption("deprecation", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val lintDocDetached =
+    lintOption("doc-detached", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintImplicitRecursion =
+    lintOption("implicit-recursion", version => version.isBetween(V2_13_3, V3_0_0))
+
+  val lintImplicitNotFound =
+    lintOption("implicit-not-found", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val lintInaccessible =
+    lintOption("inaccessible", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintInferAny =
+    lintOption("infer-any", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintMissingInterpolator =
+    lintOption("missing-interpolator", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintNullaryOverride =
+    lintOption("nullary-override", version => version.isBetween(V2_11_0, V2_13_0))
+
+  val lintNullaryUnit =
+    lintOption("nullary-unit", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintOptionImplicit =
+    lintOption("option-implicit", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintPackageObjectClasses =
+    lintOption("package-object-classes", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintPolyImplicitOverload =
+    lintOption("poly-implicit-overload", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintPrivateShadow =
+    lintOption("private-shadow", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintStarsAlign =
+    lintOption("stars-align", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintStrictUnsealedPatmat =
+    lintOption("strict-unsealed-patmat", version => version.isBetween(V2_13_4, V3_0_0))
+
+  val lintTypeParameterShadow =
+    lintOption("type-parameter-shadow", version => version.isBetween(V2_11_0, V3_0_0))
+
+  val lintUnsoundMatch =
+    lintOption("unsound-match", version => version.isBetween(V2_11_0, V2_13_0))
+
+  val disableLintBynameImplicit =
+    disableLintOption("byname-implicit", version => version.isBetween(V2_13_3, V3_0_0))
+
+  val lintOptions: Set[ScalacOption] = ListSet(
+    lintAdaptedArgs,
+    lintByNameRightAssociative,
+    lintConstant,
+    lintDelayedInitSelect,
+    lintDeprecation,
+    lintDocDetached,
+    lintImplicitRecursion,
+    lintImplicitNotFound,
+    lintInaccessible,
+    lintInferAny,
+    lintMissingInterpolator,
+    lintNullaryOverride,
+    lintNullaryUnit,
+    lintOptionImplicit,
+    lintPackageObjectClasses,
+    lintPolyImplicitOverload,
+    lintPrivateShadow,
+    lintStarsAlign,
+    lintStrictUnsealedPatmat,
+    lintTypeParameterShadow,
+    lintUnsoundMatch,
+    disableLintBynameImplicit
+  )
+
+  val advancedOptions: Set[ScalacOption] = ListSet(
+    checkInit,
+    lint
+  ) ++ lintOptions
+
+  def privateOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
+    ScalacOption(List(s"-Y$name"), isSupported)
+
+  val privateNoAdaptedArgs =
+    privateOption("no-adapted-args", version => version < V2_13_0)
+
+  val privateKindProjector =
+    privateOption("kind-projector", version => version >= V3_0_0)
+
+  def privateWarnOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
+    privateOption(s"warn-$name", isSupported)
+
+  val privateWarnDeadCode =
+    privateWarnOption("dead-code", version => version < V2_13_0)
+
+  val privateWarnExtraImplicit =
+    privateWarnOption("extra-implicit", version => version.isBetween(V2_12_0, V2_13_0))
+
+  val privateWarnInaccessible =
+    privateWarnOption("inaccessible", version => version < V2_11_0)
+
+  val privateWarnNullaryOverride =
+    privateWarnOption("nullary-override", version => version < V2_13_0)
+
+  val privateWarnNullaryUnit =
+    privateWarnOption("nullary-unit", version => version < V2_13_0)
+
+  val privateWarnNumericWiden =
+    privateWarnOption("numeric-widen", version => version < V2_13_0)
+
+  val privateWarnUnused =
+    privateWarnOption("unused", version => version.isBetween(V2_11_0, V2_12_0))
+
+  val privateWarnUnusedImport =
+    privateWarnOption("unused-import", version => version.isBetween(V2_11_0, V2_12_0))
+
+  val privateWarnValueDiscard =
+    privateWarnOption("value-discard", version => version < V2_13_0)
+
+  def privateWarnUnusedOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
+    privateWarnOption(s"unused:$name", isSupported)
+
+  val privateWarnUnusedImplicits =
+    privateWarnUnusedOption("implicits", version => version.isBetween(V2_12_0, V2_13_0))
+
+  val privateWarnUnusedImports =
+    privateWarnUnusedOption("imports", version => version.isBetween(V2_12_0, V2_13_0))
+
+  val privateWarnUnusedLocals =
+    privateWarnUnusedOption("locals", version => version.isBetween(V2_12_0, V2_13_0))
+
+  val privateWarnUnusedParams =
+    privateWarnUnusedOption("params", version => version.isBetween(V2_12_0, V2_13_0))
+
+  val privateWarnUnusedPatVars =
+    privateWarnUnusedOption("patvars", version => version.isBetween(V2_12_0, V2_13_0))
+
+  val privateWarnUnusedPrivates =
+    privateWarnUnusedOption("privates", version => version.isBetween(V2_12_0, V2_13_0))
+
+  val privateWarnUnusedOptions: Set[ScalacOption] = ListSet(
+    privateWarnUnusedImplicits,
+    privateWarnUnusedImports,
+    privateWarnUnusedLocals,
+    privateWarnUnusedParams,
+    privateWarnUnusedPatVars,
+    privateWarnUnusedPrivates
+  )
+
+  val privateWarnOptions: Set[ScalacOption] = ListSet(
+    privateWarnDeadCode,
+    privateWarnExtraImplicit,
+    privateWarnInaccessible,
+    privateWarnNullaryOverride,
+    privateWarnNullaryUnit,
+    privateWarnNumericWiden,
+    privateWarnUnused,
+    privateWarnUnusedImport,
+    privateWarnValueDiscard
+  ) ++ privateWarnUnusedOptions
+
+  val privateOptions: Set[ScalacOption] = ListSet(
+    privateNoAdaptedArgs,
+    privateKindProjector
+  ) ++ privateWarnOptions
+
+  def warnOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
+    ScalacOption(List(s"-W$name"), isSupported)
+
+  val warnDeadCode =
+    warnOption("dead-code", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnExtraImplicit =
+    warnOption("extra-implicit", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnNumericWiden =
+    warnOption("numeric-widen", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnValueDiscard =
+    warnOption("value-discard", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnError =
+    warnOption("error", version => version.isBetween(V2_13_0, V3_0_0))
+
+  def warnUnusedOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
+    ScalacOption(List(s"-Wunused:$name"), isSupported)
+
+  val warnUnusedNoWarn =
+    warnUnusedOption("nowarn", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnUnusedImplicits =
+    warnUnusedOption("implicits", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnUnusedExplicits =
+    warnUnusedOption("explicits", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnUnusedImports =
+    warnUnusedOption("imports", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnUnusedLocals =
+    warnUnusedOption("locals", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnUnusedParams =
+    warnUnusedOption("params", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnUnusedPatVars =
+    warnUnusedOption("patvars", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnUnusedPrivates =
+    warnUnusedOption("privates", version => version.isBetween(V2_13_0, V3_0_0))
+
+  val warnUnusedOptions: Set[ScalacOption] = ListSet(
+    warnUnusedNoWarn,
+    warnUnusedImplicits,
+    warnUnusedExplicits,
+    warnUnusedImports,
+    warnUnusedLocals,
+    warnUnusedParams,
+    warnUnusedPatVars,
+    warnUnusedPrivates
+  )
+
+  val warnOptions: Set[ScalacOption] = ListSet(
+    warnDeadCode,
+    warnExtraImplicit,
+    warnNumericWiden,
+    warnValueDiscard
+  ) ++ warnUnusedOptions
+
+  val fatalWarningOptions: Set[ScalacOption] = ListSet(
+    fatalWarnings,
+    warnError
+  )
+
+  val default: Set[ScalacOption] = ListSet(
+    encoding("utf8"),
+    deprecation,
+    feature,
+    unchecked
+  ) ++ languageFeatures ++ advancedOptions ++ privateOptions ++ warnOptions
+
+  def optimizerOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
+    ScalacOption(List(s"-opt$name"), isSupported)
+
+  val optimizerMethodLocal =
+    optimizerOption(":l:method", version => version.isBetween(V2_12_0, V3_0_0))
+
+  val optimizerInline =
+    optimizerOption(":l:inline", version => version.isBetween(V2_12_0, V3_0_0))
+
+  val optimizerWarnings =
+    optimizerOption("-warnings", version => version.isBetween(V2_12_0, V3_0_0))
+
+  def optimizerInlineFrom(inlineFromPackages: String*) =
+    optimizerOption(
+      s"-inline-from:${inlineFromPackages.mkString(":")}",
+      version => version.isBetween(V2_12_0, V3_0_0)
+    )
+
+  def optimizerOptions(inlineFromPackages: String*): Set[ScalacOption] = ListSet(
+    optimizerMethodLocal,
+    optimizerInline,
+    optimizerInlineFrom(inlineFromPackages: _*)
+  )
+}

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -103,34 +103,37 @@ object TpolecatPlugin extends AutoPlugin {
   val commandAliases =
     addCommandAlias(
       "tpolecatDevMode",
-      "set tpolecatOptionsMode := _root_.io.github.davidgregory084.DevMode"
+      "set ThisBuild / tpolecatOptionsMode := _root_.io.github.davidgregory084.DevMode"
     ) ++
       addCommandAlias(
         "tpolecatCiMode",
-        "set tpolecatOptionsMode := _root_.io.github.davidgregory084.CiMode"
+        "set ThisBuild / tpolecatOptionsMode := _root_.io.github.davidgregory084.CiMode"
       ) ++
       addCommandAlias(
         "tpolecatReleaseMode",
-        "set tpolecatOptionsMode := _root_.io.github.davidgregory084.ReleaseMode"
+        "set ThisBuild / tpolecatOptionsMode := _root_.io.github.davidgregory084.ReleaseMode"
       )
 
-  override def projectSettings: Seq[Setting[_]] = Seq(
-    scalacOptions              := scalacOptionsFor(scalaVersion.value, tpolecatScalacOptions.value),
+  override def buildSettings: Seq[Setting[_]] = Seq(
     tpolecatDefaultOptionsMode := CiMode,
     tpolecatDevModeEnvVar      := "SBT_TPOLECAT_DEV",
     tpolecatCiModeEnvVar       := "SBT_TPOLECAT_CI",
     tpolecatReleaseModeEnvVar  := "SBT_TPOLECAT_RELEASE",
-    tpolecatDevModeOptions     := ScalacOptions.default,
-    tpolecatCiModeOptions      := tpolecatDevModeOptions.value ++ ScalacOptions.fatalWarningOptions,
-    tpolecatReleaseModeOptions := tpolecatCiModeOptions.value + ScalacOptions.optimizerMethodLocal,
     tpolecatOptionsMode := {
       if (sys.env.get(tpolecatReleaseModeEnvVar.value).nonEmpty) ReleaseMode
       else if (sys.env.get(tpolecatCiModeEnvVar.value).nonEmpty) CiMode
       else if (sys.env.get(tpolecatDevModeEnvVar.value).nonEmpty) DevMode
       else tpolecatDefaultOptionsMode.value
-    },
+    }
+  ) ++ commandAliases
+
+  override def projectSettings: Seq[Setting[_]] = Seq(
+    scalacOptions              := scalacOptionsFor(scalaVersion.value, tpolecatScalacOptions.value),
+    tpolecatDevModeOptions     := ScalacOptions.default,
+    tpolecatCiModeOptions      := tpolecatDevModeOptions.value ++ ScalacOptions.fatalWarningOptions,
+    tpolecatReleaseModeOptions := tpolecatCiModeOptions.value + ScalacOptions.optimizerMethodLocal,
     tpolecatScalacOptions := {
-      tpolecatOptionsMode.value match {
+      (ThisBuild / tpolecatOptionsMode).value match {
         case DevMode     => tpolecatDevModeOptions.value
         case CiMode      => tpolecatCiModeOptions.value
         case ReleaseMode => tpolecatReleaseModeOptions.value
@@ -138,5 +141,5 @@ object TpolecatPlugin extends AutoPlugin {
     },
     Compile / console / tpolecatScalacOptions ~= tpolecatConsoleOptionsFilter,
     Test / console / tpolecatScalacOptions ~= tpolecatConsoleOptionsFilter
-  ) ++ commandAliases
+  )
 }

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -116,12 +116,12 @@ object TpolecatPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Setting[_]] = Seq(
     scalacOptions              := scalacOptionsFor(scalaVersion.value, tpolecatScalacOptions.value),
-    tpolecatDefaultOptionsMode := DevMode,
+    tpolecatDefaultOptionsMode := CiMode,
     tpolecatDevModeEnvVar      := "SBT_TPOLECAT_DEV",
     tpolecatCiModeEnvVar       := "SBT_TPOLECAT_CI",
     tpolecatReleaseModeEnvVar  := "SBT_TPOLECAT_RELEASE",
     tpolecatDevModeOptions     := ScalacOptions.default,
-    tpolecatCiModeOptions      := ScalacOptions.default ++ ScalacOptions.fatalWarningOptions,
+    tpolecatCiModeOptions      := tpolecatDevModeOptions.value ++ ScalacOptions.fatalWarningOptions,
     tpolecatReleaseModeOptions := tpolecatCiModeOptions.value + ScalacOptions.optimizerMethodLocal,
     tpolecatOptionsMode := {
       if (sys.env.get(tpolecatReleaseModeEnvVar.value).nonEmpty) ReleaseMode

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -1,47 +1,235 @@
 import scala.util.Try
+import munit.Assertions._
 
-val scala2Versions = Seq(
-  "2.11.12",
-  "2.12.15",
-  "2.13.8"
+val Scala211 = "2.11.12"
+val Scala212 = "2.12.15"
+val Scala213 = "2.13.8"
+val Scala30  = "3.0.2"
+val Scala31  = "3.1.1"
+
+crossScalaVersions := Seq(
+  Scala211,
+  Scala212,
+  Scala213,
+  Scala30,
+  Scala31
 )
 
-val scala3Versions = Seq(
-  "3.0.2",
-  "3.1.1"
-)
+tpolecatReleaseModeOptions ++= ScalacOptions.optimizerOptions("**")
 
-crossScalaVersions := {
-  object ExtractVersion {
-    val sbtVersionMatch = raw"(\d+)\.(\d+)\.(\d+)".r
-    def unapply(sbtVersion: String): Option[(Long, Long, Long)] = {
-      sbtVersion match {
-        case sbtVersionMatch(major, minor, patch) =>
-          for {
-            maj <- Try(major.toLong).toOption
-            min <- Try(minor.toLong).toOption
-            p <- Try(patch.toLong).toOption
-          } yield (maj, min, p)
+val Scala211Options =
+  Seq(
+    "-encoding",
+    "utf8",
+    "-deprecation",
+    "-feature",
+    "-unchecked",
+    "-language:existentials",
+    "-language:experimental.macros",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-Xcheckinit",
+    "-Xlint:adapted-args",
+    "-Xlint:by-name-right-associative",
+    "-Xlint:delayedinit-select",
+    "-Xlint:doc-detached",
+    "-Xlint:inaccessible",
+    "-Xlint:infer-any",
+    "-Xlint:missing-interpolator",
+    "-Xlint:nullary-override",
+    "-Xlint:nullary-unit",
+    "-Xlint:option-implicit",
+    "-Xlint:package-object-classes",
+    "-Xlint:poly-implicit-overload",
+    "-Xlint:private-shadow",
+    "-Xlint:stars-align",
+    "-Xlint:type-parameter-shadow",
+    "-Xlint:unsound-match",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-nullary-override",
+    "-Ywarn-nullary-unit",
+    "-Ywarn-numeric-widen",
+    "-Ywarn-unused",
+    "-Ywarn-unused-import",
+    "-Ywarn-value-discard"
+  )
 
-        case _ =>
-          None
-      }
-    }
+val Scala212Options =
+  Seq(
+    "-encoding",
+    "utf8",
+    "-deprecation",
+    "-feature",
+    "-unchecked",
+    "-language:existentials",
+    "-language:experimental.macros",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-Xcheckinit",
+    "-Xlint:adapted-args",
+    "-Xlint:by-name-right-associative",
+    "-Xlint:constant",
+    "-Xlint:delayedinit-select",
+    "-Xlint:doc-detached",
+    "-Xlint:inaccessible",
+    "-Xlint:infer-any",
+    "-Xlint:missing-interpolator",
+    "-Xlint:nullary-override",
+    "-Xlint:nullary-unit",
+    "-Xlint:option-implicit",
+    "-Xlint:package-object-classes",
+    "-Xlint:poly-implicit-overload",
+    "-Xlint:private-shadow",
+    "-Xlint:stars-align",
+    "-Xlint:type-parameter-shadow",
+    "-Xlint:unsound-match",
+    "-Yno-adapted-args",
+    "-Ywarn-dead-code",
+    "-Ywarn-extra-implicit",
+    "-Ywarn-nullary-override",
+    "-Ywarn-nullary-unit",
+    "-Ywarn-numeric-widen",
+    "-Ywarn-value-discard",
+    "-Ywarn-unused:implicits",
+    "-Ywarn-unused:imports",
+    "-Ywarn-unused:locals",
+    "-Ywarn-unused:params",
+    "-Ywarn-unused:patvars",
+    "-Ywarn-unused:privates"
+  )
+
+val Scala213Options =
+  Seq(
+    "-encoding",
+    "utf8",
+    "-feature",
+    "-unchecked",
+    "-language:existentials",
+    "-language:experimental.macros",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-Xcheckinit",
+    "-Xlint:adapted-args",
+    "-Xlint:constant",
+    "-Xlint:delayedinit-select",
+    "-Xlint:deprecation",
+    "-Xlint:doc-detached",
+    "-Xlint:implicit-recursion",
+    "-Xlint:implicit-not-found",
+    "-Xlint:inaccessible",
+    "-Xlint:infer-any",
+    "-Xlint:missing-interpolator",
+    "-Xlint:nullary-unit",
+    "-Xlint:option-implicit",
+    "-Xlint:package-object-classes",
+    "-Xlint:poly-implicit-overload",
+    "-Xlint:private-shadow",
+    "-Xlint:stars-align",
+    "-Xlint:strict-unsealed-patmat",
+    "-Xlint:type-parameter-shadow",
+    "-Xlint:-byname-implicit",
+    "-Wdead-code",
+    "-Wextra-implicit",
+    "-Wnumeric-widen",
+    "-Wvalue-discard",
+    "-Wunused:nowarn",
+    "-Wunused:implicits",
+    "-Wunused:explicits",
+    "-Wunused:imports",
+    "-Wunused:locals",
+    "-Wunused:params",
+    "-Wunused:patvars",
+    "-Wunused:privates"
+  )
+
+val Scala30Options =
+  Seq(
+    "-encoding",
+    "utf8",
+    "-deprecation",
+    "-feature",
+    "-unchecked",
+    "-language:experimental.macros",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-Ykind-projector"
+  )
+
+val Scala31Options =
+  Seq(
+    "-encoding",
+    "utf8",
+    "-deprecation",
+    "-feature",
+    "-unchecked",
+    "-language:experimental.macros",
+    "-language:higherKinds",
+    "-language:implicitConversions",
+    "-Ykind-projector"
+  )
+
+TaskKey[Unit]("checkDevMode") := {
+  val scalaV = scalaVersion.value
+
+  val expectedOptions = scalaV match {
+    case Scala211 => Scala211Options ++ Seq("-Ypartial-unification")
+    case Scala212 => Scala212Options ++ Seq("-Ypartial-unification")
+    case Scala213 => Scala213Options
+    case Scala30  => Scala30Options
+    case Scala31  => Scala31Options
   }
 
-  def supportedSbtVersions(major: Long, minor: Long, patch: Long): Boolean =
-    (major, minor, patch) match {
-      case (1, 5, patch) if patch >= 2 => true
-      case (1, minor, _) if minor > 5 => true
-      case (major, _, _) if major > 1 => true
-      case _ => false
-    }
+  val actualOptions = scalacOptions.value
 
-  sbtVersion.value match {
-    case ExtractVersion(major, minor, patch) if supportedSbtVersions(major, minor, patch) =>
-      scala2Versions ++ scala3Versions
+  assertEquals(actualOptions, expectedOptions)
+}
 
-    case _ =>
-      scala2Versions
+TaskKey[Unit]("checkCiMode") := {
+  val scalaV = scalaVersion.value
+
+  val expectedOptions = scalaV match {
+    case Scala211 => Scala211Options ++ Seq("-Xfatal-warnings", "-Ypartial-unification")
+    case Scala212 => Scala212Options ++ Seq("-Xfatal-warnings", "-Ypartial-unification")
+    case Scala213 => Scala213Options ++ Seq("-Werror")
+    case Scala30  => Scala30Options ++ Seq("-Xfatal-warnings")
+    case Scala31  => Scala31Options ++ Seq("-Xfatal-warnings")
   }
+
+  val actualOptions = scalacOptions.value
+
+  assertEquals(actualOptions, expectedOptions)
+}
+
+TaskKey[Unit]("checkReleaseMode") := {
+  val scalaV = scalaVersion.value
+
+  val expectedOptions = scalaV match {
+    case Scala211 =>
+      Scala211Options ++ Seq(
+        "-Xfatal-warnings",
+        "-Ypartial-unification"
+      )
+    case Scala212 =>
+      Scala212Options ++ Seq(
+        "-Xfatal-warnings",
+        "-opt:l:method",
+        "-opt:l:inline",
+        "-opt-inline-from:**",
+        "-Ypartial-unification"
+      )
+    case Scala213 =>
+      Scala213Options ++ Seq(
+        "-Werror",
+        "-opt:l:method",
+        "-opt:l:inline",
+        "-opt-inline-from:**"
+      )
+    case Scala30 => Scala30Options ++ Seq("-Xfatal-warnings")
+    case Scala31 => Scala31Options ++ Seq("-Xfatal-warnings")
+  }
+
+  val actualOptions = scalacOptions.value
+
+  assertEquals(actualOptions, expectedOptions)
 }

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/project/build.properties
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.6.2

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/project/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/project/build.sbt
@@ -1,0 +1,1 @@
+libraryDependencies += "org.scalameta" %% "munit" % "0.7.29"

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/test
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/test
@@ -1,5 +1,5 @@
-# Dev mode is the default mode
-> +checkDevMode
+# CI mode is the default mode
+> +checkCiMode
 > +compile
 # Check dev mode options
 > +tpolecatDevMode

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/test
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/test
@@ -2,14 +2,14 @@
 > +checkCiMode
 > +compile
 # Check dev mode options
-> +tpolecatDevMode
+> tpolecatDevMode
 > +checkDevMode
 > +compile
 # Check CI mode options
-> +tpolecatCiMode
+> tpolecatCiMode
 > +checkCiMode
 > +compile
 # Check release mode options
-> +tpolecatReleaseMode
+> tpolecatReleaseMode
 > +checkReleaseMode
 > +compile

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/test
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/test
@@ -1,2 +1,15 @@
-> +show scalacOptions
+# Dev mode is the default mode
+> +checkDevMode
+> +compile
+# Check dev mode options
+> +tpolecatDevMode
+> +checkDevMode
+> +compile
+# Check CI mode options
+> +tpolecatCiMode
+> +checkCiMode
+> +compile
+# Check release mode options
+> +tpolecatReleaseMode
+> +checkReleaseMode
 > +compile

--- a/src/test/scala/io/github/davidgregory084/TpolecatPluginSuite.scala
+++ b/src/test/scala/io/github/davidgregory084/TpolecatPluginSuite.scala
@@ -29,7 +29,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
     forAll(versionGen, versionGen, versionGen) {
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
-        val scalacOption   = ScalacOption(List("-some-opt"))
+        val scalacOption   = new ScalacOption(List("-some-opt"))
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when neither addedIn nor removedIn"
@@ -42,7 +42,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj - 1, 0, 0)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when addedIn matches past major release"
@@ -55,7 +55,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj, currentMin - 1, 0)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when addedIn matches past minor release"
@@ -68,7 +68,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj, currentMin, currentPatch - 1)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when addedIn matches past patch release"
@@ -80,7 +80,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
     forAll(versionGen, versionGen, versionGen) {
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= currentVersion)
+        val scalacOption = new ScalacOption(List("-some-opt"), version => version >= currentVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when addedIn matches this minor/patch release"
@@ -93,7 +93,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj + 1, currentMin, currentPatch)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when addedIn matches a future major release"
@@ -106,7 +106,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj, currentMin + 1, currentPatch)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when addedIn matches a future minor release"
@@ -119,7 +119,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val addedVersion   = ScalaVersion(currentMaj, currentMin, currentPatch + 1)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        val scalacOption   = new ScalacOption(List("-some-opt"), version => version >= addedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when addedIn matches a future patch release"
@@ -132,7 +132,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj + 1, 0, 0)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when removedIn matches next major release"
@@ -145,7 +145,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj, currentMin + 1, currentPatch)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when removedIn matches next minor release"
@@ -158,7 +158,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj, currentMin, currentPatch + 1)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
         assert(
           scalacOption.isSupported(currentVersion),
           "Should be valid when removedIn matches next patch release"
@@ -170,7 +170,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
     forAll(versionGen, versionGen, versionGen) {
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version < currentVersion)
+        val scalacOption = new ScalacOption(List("-some-opt"), version => version < currentVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when removedIn matches this minor/patch release"
@@ -183,7 +183,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj - 1, currentMin, currentPatch)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when removedIn matches an old major release"
@@ -196,7 +196,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj, currentMin - 1, currentPatch)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when removedIn matches an old minor release"
@@ -209,7 +209,7 @@ class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyCheck
       (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
         val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
         val removedVersion = ScalaVersion(currentMaj, currentMin, currentPatch - 1)
-        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        val scalacOption = new ScalacOption(List("-some-opt"), version => version < removedVersion)
         assert(
           !scalacOption.isSupported(currentVersion),
           "Should not be valid when removedIn matches an old patch release"

--- a/src/test/scala/io/github/davidgregory084/TpolecatPluginSuite.scala
+++ b/src/test/scala/io/github/davidgregory084/TpolecatPluginSuite.scala
@@ -16,191 +16,204 @@
 
 package io.github.davidgregory084
 
+import org.scalacheck.Gen
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.scalacheck.Gen
-import org.scalacheck.Prop._
 
-import TpolecatPlugin._
-import TpolecatPlugin.autoImport._
+import scala.Ordering.Implicits._
 
 class TpolecatPluginSuite extends AnyFunSuite with ScalaCheckDrivenPropertyChecks {
   val versionGen = Gen.chooseNum(0L, 20L)
 
-  test("valid when neither addedIn nor removedIn") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val scalacOption = ScalacOption("-some-opt", None, None)
-      assert(
-        validFor(currentVersion)(scalacOption),
-        "Should be valid when neither addedIn nor removedIn"
-      )
+  test("valid when no version predicate") {
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val scalacOption   = ScalacOption(List("-some-opt"))
+        assert(
+          scalacOption.isSupported(currentVersion),
+          "Should be valid when neither addedIn nor removedIn"
+        )
     }
   }
 
   test("valid when added in past major release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val addedVersion = Version(currentMaj - 1, 0, 0)
-      val scalacOption = ScalacOption("-some-opt", addedIn = Some(addedVersion))
-      assert(
-        validFor(currentVersion)(scalacOption),
-        "Should be valid when addedIn matches past major release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val addedVersion   = ScalaVersion(currentMaj - 1, 0, 0)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        assert(
+          scalacOption.isSupported(currentVersion),
+          "Should be valid when addedIn matches past major release"
+        )
     }
   }
 
   test("valid when added in past minor release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val addedVersion = Version(currentMaj, currentMin - 1, 0)
-      val scalacOption = ScalacOption("-some-opt", addedIn = Some(addedVersion))
-      assert(
-        validFor(currentVersion)(scalacOption),
-        "Should be valid when addedIn matches past minor release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val addedVersion   = ScalaVersion(currentMaj, currentMin - 1, 0)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        assert(
+          scalacOption.isSupported(currentVersion),
+          "Should be valid when addedIn matches past minor release"
+        )
     }
   }
 
   test("valid when added in past patch release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val addedVersion = Version(currentMaj, currentMin, currentPatch - 1)
-      val scalacOption = ScalacOption("-some-opt", addedIn = Some(addedVersion))
-      assert(
-        validFor(currentVersion)(scalacOption),
-        "Should be valid when addedIn matches past patch release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val addedVersion   = ScalaVersion(currentMaj, currentMin, currentPatch - 1)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        assert(
+          scalacOption.isSupported(currentVersion),
+          "Should be valid when addedIn matches past patch release"
+        )
     }
   }
 
   test("valid when added in this minor/patch release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val scalacOption = ScalacOption("-some-opt", addedIn = Some(currentVersion))
-      assert(
-        validFor(currentVersion)(scalacOption),
-        "Should be valid when addedIn matches this minor/patch release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= currentVersion)
+        assert(
+          scalacOption.isSupported(currentVersion),
+          "Should be valid when addedIn matches this minor/patch release"
+        )
     }
   }
 
   test("not valid when added in a future major release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val addedVersion = Version(currentMaj + 1, currentMin, currentPatch)
-      val scalacOption = ScalacOption("-some-opt", addedIn = Some(addedVersion))
-      assert(
-        !validFor(currentVersion)(scalacOption),
-        "Should not be valid when addedIn matches a future major release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val addedVersion   = ScalaVersion(currentMaj + 1, currentMin, currentPatch)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        assert(
+          !scalacOption.isSupported(currentVersion),
+          "Should not be valid when addedIn matches a future major release"
+        )
     }
   }
 
   test("not valid when added in a future minor release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val addedVersion = Version(currentMaj, currentMin + 1, currentPatch)
-      val scalacOption = ScalacOption("-some-opt", addedIn = Some(addedVersion))
-      assert(
-        !validFor(currentVersion)(scalacOption),
-        "Should not be valid when addedIn matches a future minor release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val addedVersion   = ScalaVersion(currentMaj, currentMin + 1, currentPatch)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        assert(
+          !scalacOption.isSupported(currentVersion),
+          "Should not be valid when addedIn matches a future minor release"
+        )
     }
   }
 
   test("not valid when added in a future patch release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val addedVersion = Version(currentMaj, currentMin, currentPatch + 1)
-      val scalacOption = ScalacOption("-some-opt", addedIn = Some(addedVersion))
-      assert(
-        !validFor(currentVersion)(scalacOption),
-        "Should not be valid when addedIn matches a future patch release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val addedVersion   = ScalaVersion(currentMaj, currentMin, currentPatch + 1)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version >= addedVersion)
+        assert(
+          !scalacOption.isSupported(currentVersion),
+          "Should not be valid when addedIn matches a future patch release"
+        )
     }
   }
 
   test("valid when removed in next major release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val removedVersion = Version(currentMaj + 1, 0, 0)
-      val scalacOption = ScalacOption("-some-opt", None, removedIn = Some(removedVersion))
-      assert(
-        validFor(currentVersion)(scalacOption),
-        "Should be valid when removedIn matches next major release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val removedVersion = ScalaVersion(currentMaj + 1, 0, 0)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        assert(
+          scalacOption.isSupported(currentVersion),
+          "Should be valid when removedIn matches next major release"
+        )
     }
   }
 
   test("valid when removed in next minor release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val removedVersion = Version(currentMaj, currentMin + 1, currentPatch)
-      val scalacOption = ScalacOption("-some-opt", None, removedIn = Some(removedVersion))
-      assert(
-        validFor(currentVersion)(scalacOption),
-        "Should be valid when removedIn matches next minor release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val removedVersion = ScalaVersion(currentMaj, currentMin + 1, currentPatch)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        assert(
+          scalacOption.isSupported(currentVersion),
+          "Should be valid when removedIn matches next minor release"
+        )
     }
   }
 
   test("valid when removed in next patch release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val removedVersion = Version(currentMaj, currentMin, currentPatch + 1)
-      val scalacOption = ScalacOption("-some-opt", None, removedIn = Some(removedVersion))
-      assert(
-        validFor(currentVersion)(scalacOption),
-        "Should be valid when removedIn matches next patch release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val removedVersion = ScalaVersion(currentMaj, currentMin, currentPatch + 1)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        assert(
+          scalacOption.isSupported(currentVersion),
+          "Should be valid when removedIn matches next patch release"
+        )
     }
   }
 
   test("not valid when removed in this minor/patch release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val scalacOption = ScalacOption("-some-opt", None, removedIn = Some(currentVersion))
-      assert(
-        !validFor(currentVersion)(scalacOption),
-        "Should not be valid when removedIn matches this minor/patch release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version < currentVersion)
+        assert(
+          !scalacOption.isSupported(currentVersion),
+          "Should not be valid when removedIn matches this minor/patch release"
+        )
     }
   }
 
   test("not valid when removed in an old major release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val removedVersion = Version(currentMaj - 1, currentMin, currentPatch)
-      val scalacOption = ScalacOption("-some-opt", None, removedIn = Some(removedVersion))
-      assert(
-        !validFor(currentVersion)(scalacOption),
-        "Should not be valid when removedIn matches an old major release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val removedVersion = ScalaVersion(currentMaj - 1, currentMin, currentPatch)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        assert(
+          !scalacOption.isSupported(currentVersion),
+          "Should not be valid when removedIn matches an old major release"
+        )
     }
   }
 
   test("not valid when removed in an old minor release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val removedVersion = Version(currentMaj, currentMin - 1, currentPatch)
-      val scalacOption = ScalacOption("-some-opt", None, removedIn = Some(removedVersion))
-      assert(
-        !validFor(currentVersion)(scalacOption),
-        "Should not be valid when removedIn matches an old minor release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val removedVersion = ScalaVersion(currentMaj, currentMin - 1, currentPatch)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        assert(
+          !scalacOption.isSupported(currentVersion),
+          "Should not be valid when removedIn matches an old minor release"
+        )
     }
   }
 
   test("not valid when removed in an old patch release") {
-    forAll(versionGen, versionGen, versionGen) { (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
-      val currentVersion = Version(currentMaj, currentMin, currentPatch)
-      val removedVersion = Version(currentMaj, currentMin, currentPatch - 1)
-      val scalacOption = ScalacOption("-some-opt", None, removedIn = Some(removedVersion))
-      assert(
-        !validFor(currentVersion)(scalacOption),
-        "Should not be valid when removedIn matches an old patch release"
-      )
+    forAll(versionGen, versionGen, versionGen) {
+      (currentMaj: Long, currentMin: Long, currentPatch: Long) =>
+        val currentVersion = ScalaVersion(currentMaj, currentMin, currentPatch)
+        val removedVersion = ScalaVersion(currentMaj, currentMin, currentPatch - 1)
+        val scalacOption   = ScalacOption(List("-some-opt"), version => version < removedVersion)
+        assert(
+          !scalacOption.isSupported(currentVersion),
+          "Should not be valid when removedIn matches an old patch release"
+        )
     }
   }
 }


### PR DESCRIPTION
This adds a concept of modes and some default option sets to the plugin.

`DevMode` - this mode uses `ScalacOptions.default`, an always-on set of options
`CiMode` - this mode uses the dev mode options plus `ScalacOption.fatalWarningOptions`
`ReleaseMode` - this mode uses the CI mode options plus `-opt:l:method` method-local optimisation by default

Inlining can be enabled by using `ScalacOptions.optimizerOptions` with the packages to inline from e.g. `ScalacOptions.optimizerOptions("scala.**")` to inline from scala packages or `ScalacOptions.optimizerOptions("**")` to inline from everywhere.

It adds command aliases to enable each mode

`tpolecatDevMode` - sets the mode to `DevMode`
`tpolecatCiMode` - sets the mode to `CiMode`
`tpolecatReleaseMode` - sets the mode to `ReleaseMode`

These modes can be enabled by default by using environment variables.
The environment variable to use for each mode can be configured using the keys `tpolecatDevModeEnvVar`, `tpolecatCiModeEnvVar`, `tpolecatReleaseModeEnvVar`.

The default environment variables to use for this are `SBT_TPOLECAT_DEV`, `SBT_TPOLECAT_CI`, `SBT_TPOLECAT_RELEASE`. The most elevated mode "wins" when multiple variables are set, i.e. if both CI and release variables are set, release mode is used.