### PR TITLE
Make -Xfatal-warnings a universal option again

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ You can customise the environment variable that is used to enable this mode by m
 
 To enable the continuous integration mode, use the `tpolecatCiMode` command or define the environment variable `SBT_TPOLECAT_CI`.
 
-In this mode all development mode options are enabled, and the fatal warning options (`-Xfatal-warnings` / `-Werror`) are added as appropriate for your Scala version.
+In this mode all development mode options are enabled, and the fatal warnings option (`-Xfatal-warnings` ) is added.
 
-You can customise the options that are enabled in this mode by modifying the `tpolecatCiModeOptions` key. Default: `tpolecatDevModeOptions.value ++ ScalacOptions.fatalWarningOptions`.
+You can customise the options that are enabled in this mode by modifying the `tpolecatCiModeOptions` key. Default: `tpolecatDevModeOptions.value + ScalacOptions.fatalWarnings`.
 
 For example, to disable unused linting you could customise the CI options as follows:
 

--- a/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -94,7 +94,7 @@ trait ScalacOptions {
   /** Fail the compilation if there are any warnings.
     */
   val fatalWarnings =
-    advancedOption("fatal-warnings", version => version < V2_13_0 || version >= V3_0_0)
+    advancedOption("fatal-warnings")
 
   /** Enable recommended warnings.
     */

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -130,7 +130,7 @@ object TpolecatPlugin extends AutoPlugin {
   override def projectSettings: Seq[Setting[_]] = Seq(
     scalacOptions              := scalacOptionsFor(scalaVersion.value, tpolecatScalacOptions.value),
     tpolecatDevModeOptions     := ScalacOptions.default,
-    tpolecatCiModeOptions      := tpolecatDevModeOptions.value ++ ScalacOptions.fatalWarningOptions,
+    tpolecatCiModeOptions      := tpolecatDevModeOptions.value + ScalacOptions.fatalWarnings,
     tpolecatReleaseModeOptions := tpolecatCiModeOptions.value + ScalacOptions.optimizerMethodLocal,
     tpolecatScalacOptions := {
       (ThisBuild / tpolecatOptionsMode).value match {

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -191,7 +191,7 @@ TaskKey[Unit]("checkCiMode") := {
   val expectedOptions = scalaV match {
     case Scala211 => Scala211Options ++ Seq("-Xfatal-warnings", "-Ypartial-unification")
     case Scala212 => Scala212Options ++ Seq("-Xfatal-warnings", "-Ypartial-unification")
-    case Scala213 => Scala213Options ++ Seq("-Werror")
+    case Scala213 => Scala213Options ++ Seq("-Xfatal-warnings")
     case Scala30  => Scala30Options ++ Seq("-Xfatal-warnings")
     case Scala31  => Scala31Options ++ Seq("-Xfatal-warnings")
   }
@@ -220,7 +220,7 @@ TaskKey[Unit]("checkReleaseMode") := {
       )
     case Scala213 =>
       Scala213Options ++ Seq(
-        "-Werror",
+        "-Xfatal-warnings",
         "-opt:l:method",
         "-opt:l:inline",
         "-opt-inline-from:**"


### PR DESCRIPTION
I have noticed that many users filter out `-Xfatal-warnings` explicitly - this means that the approach used in 0.2.0 of enabling `-Werror` for >= 2.13 < 3.0.0 does not work well for them as `-Werror` does not get filtered out.