### PR TITLE
Make settings with dependencies into derived settings

### DIFF
--- a/src/main/scala/io/github/davidgregory084/ScalacOption.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOption.scala
@@ -36,4 +36,7 @@ class ScalacOption(
       case that: ScalacOption => this.tokens == that.tokens
       case _                  => false
     }
+
+  override def toString =
+    "ScalacOption(" + tokens.mkString(" ") + ")"
 }

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -128,17 +128,28 @@ object TpolecatPlugin extends AutoPlugin {
   ) ++ commandAliases
 
   override def projectSettings: Seq[Setting[_]] = Seq(
-    Def.derive(scalacOptions := scalacOptionsFor(scalaVersion.value, tpolecatScalacOptions.value)),
-    tpolecatDevModeOptions     := ScalacOptions.default,
-    tpolecatCiModeOptions      := tpolecatDevModeOptions.value + ScalacOptions.fatalWarnings,
-    tpolecatReleaseModeOptions := tpolecatCiModeOptions.value + ScalacOptions.optimizerMethodLocal,
-    tpolecatScalacOptions := {
-      (ThisBuild / tpolecatOptionsMode).value match {
+    Def.derive(
+      scalacOptions := scalacOptionsFor(scalaVersion.value, tpolecatScalacOptions.value)
+    ),
+
+    tpolecatDevModeOptions := ScalacOptions.default,
+
+    Def.derive(
+      tpolecatCiModeOptions := tpolecatDevModeOptions.value + ScalacOptions.fatalWarnings
+    ),
+
+    Def.derive(
+      tpolecatReleaseModeOptions := tpolecatCiModeOptions.value + ScalacOptions.optimizerMethodLocal
+    ),
+
+    Def.derive(tpolecatScalacOptions := {
+      tpolecatOptionsMode.value match {
         case DevMode     => tpolecatDevModeOptions.value
         case CiMode      => tpolecatCiModeOptions.value
         case ReleaseMode => tpolecatReleaseModeOptions.value
       }
-    },
+    }),
+
     Compile / console / tpolecatScalacOptions ~= tpolecatConsoleOptionsFilter,
     Test / console / tpolecatScalacOptions ~= tpolecatConsoleOptionsFilter
   )

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -128,7 +128,7 @@ object TpolecatPlugin extends AutoPlugin {
   ) ++ commandAliases
 
   override def projectSettings: Seq[Setting[_]] = Seq(
-    scalacOptions              := scalacOptionsFor(scalaVersion.value, tpolecatScalacOptions.value),
+    Def.derive(scalacOptions := scalacOptionsFor(scalaVersion.value, tpolecatScalacOptions.value)),
     tpolecatDevModeOptions     := ScalacOptions.default,
     tpolecatCiModeOptions      := tpolecatDevModeOptions.value + ScalacOptions.fatalWarnings,
     tpolecatReleaseModeOptions := tpolecatCiModeOptions.value + ScalacOptions.optimizerMethodLocal,


### PR DESCRIPTION
This fixes a problem I noticed in outwatch/outwatch#599:

 If we don't declare `scalacOptions` as a derived setting, then manipulating `tpolecatScalacOptions` in other dependency configurations doesn't work.

This means that (for example), modifying `Test / tpolecatScalacOptions` to filter out fatal warnings does not affect the resulting `Test / scalacOptions` as they are only based on `Compile / scalacOptions`.

Likewise, for other settings that are usually used while scoped to a particular dependency configuration, if we don't make those into derived settings then they won't react to changes in their scoped dependencies either.