### PR TITLE
Add -Xsource and -source options to the ScalacOptions DSL.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+import com.typesafe.tools.mima.core._
+
 // Common settings
 
 name         := "sbt-tpolecat"
@@ -52,6 +54,64 @@ ThisBuild / versionScheme := Some(VersionScheme.EarlySemVer)
 
 mimaPreviousArtifacts := Set(
   projectID.value.withRevision("0.2.0")
+)
+
+mimaBinaryIssueFilters ++= Seq(
+  // New ScalacOptions DSL methods
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.source210"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.source211"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.source212"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.source213"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.source3"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.sourceFuture"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.sourceFutureMigration"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.source3Migration"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.source31"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source210_="
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source211_="
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source212_="
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source213_="
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source3_="
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$sourceFuture_="
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$sourceFutureMigration_="
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source3Migration_="
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source31_="
+  )
 )
 
 // Testing

--- a/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
@@ -26,12 +26,15 @@ case class ScalaVersion(major: Long, minor: Long, patch: Long) {
 object ScalaVersion {
   val V2_11_0 = ScalaVersion(2, 11, 0)
   val V2_12_0 = ScalaVersion(2, 12, 0)
+  val V2_12_2 = ScalaVersion(2, 12, 2)
   val V2_13_0 = ScalaVersion(2, 13, 0)
+  val V2_13_2 = ScalaVersion(2, 13, 2)
   val V2_13_3 = ScalaVersion(2, 13, 3)
   val V2_13_4 = ScalaVersion(2, 13, 4)
   val V2_13_5 = ScalaVersion(2, 13, 5)
   val V2_13_6 = ScalaVersion(2, 13, 6)
   val V3_0_0  = ScalaVersion(3, 0, 0)
+  val V3_1_0  = ScalaVersion(3, 1, 0)
 
   implicit val scalaVersionOrdering: Ordering[ScalaVersion] =
     Ordering.by(version => (version.major, version.minor, version.patch))

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -15,6 +15,11 @@ crossScalaVersions := Seq(
   Scala31
 )
 
+tpolecatDevModeOptions ++= Set(
+  ScalacOptions.source213,
+  ScalacOptions.source3Migration
+)
+
 tpolecatReleaseModeOptions ++= ScalacOptions.optimizerOptions("**")
 
 val Scala211Options =
@@ -96,7 +101,8 @@ val Scala212Options =
     "-Ywarn-unused:locals",
     "-Ywarn-unused:params",
     "-Ywarn-unused:patvars",
-    "-Ywarn-unused:privates"
+    "-Ywarn-unused:privates",
+    "-Xsource:2.13"
   )
 
 val Scala213Options =
@@ -140,7 +146,8 @@ val Scala213Options =
     "-Wunused:locals",
     "-Wunused:params",
     "-Wunused:patvars",
-    "-Wunused:privates"
+    "-Wunused:privates",
+    "-Xsource:2.13"
   )
 
 val Scala30Options =
@@ -153,7 +160,9 @@ val Scala30Options =
     "-language:experimental.macros",
     "-language:higherKinds",
     "-language:implicitConversions",
-    "-Ykind-projector"
+    "-Ykind-projector",
+    "-source",
+    "3.0-migration"
   )
 
 val Scala31Options =
@@ -166,7 +175,9 @@ val Scala31Options =
     "-language:experimental.macros",
     "-language:higherKinds",
     "-language:implicitConversions",
-    "-Ykind-projector"
+    "-Ykind-projector",
+    "-source",
+    "3.0-migration"
   )
 
 TaskKey[Unit]("checkDevMode") := {


### PR DESCRIPTION
Adds -Xsource and -source options to the DSL.

`source3` only exists in the DSL for Scala 2.x since `-source 3` is default for Scala 3.x.