### PR TITLE
Fix addition of unwanted options to console task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vscode/
 target/
 metals.sbt
+.idea/

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ Instead you should modify the `tpolecatScalacOptions` key or the options key for
 
 ### Configuring the REPL
 
-To filter out scala compiler options that don't work well in the REPL, use the `tpolecatConsoleOptionsFilter`.
+To filter out scala compiler options that don't work well in the REPL, use the `tpolecatExcludeOptions`.
 
-By default the plugin only applies this filter to the `console` task in the `Compile` and `Test` configurations.
+By default, the plugin only applies this filter to the `console` task in the `Compile` and `Test` configurations.
 
 For example, to apply this filter to the `console` task in the `IntegrationTest` configuration you can do the following:
 
 ```scala
-IntegrationTest / console / tpolecatScalacOptions ~= tpolecatConsoleOptionsFilter
+IntegrationTest / console / tpolecatExcludeOptions ++= ScalacOptions.defaultConsoleExclude
 ```
 
 ### Modes

--- a/build.sbt
+++ b/build.sbt
@@ -52,67 +52,9 @@ ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports"
 
 ThisBuild / versionScheme := Some(VersionScheme.EarlySemVer)
 
-mimaPreviousArtifacts := Set(
-  projectID.value.withRevision("0.2.0")
-)
+mimaPreviousArtifacts := Set.empty
 
-mimaBinaryIssueFilters ++= Seq(
-  // New ScalacOptions DSL methods
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.source210"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.source211"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.source212"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.source213"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.source3"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.sourceFuture"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.sourceFutureMigration"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.source3Migration"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.source31"
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source210_="
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source211_="
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source212_="
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source213_="
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source3_="
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$sourceFuture_="
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$sourceFutureMigration_="
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source3Migration_="
-  ),
-  ProblemFilters.exclude[ReversedMissingMethodProblem](
-    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$source31_="
-  )
-)
+mimaBinaryIssueFilters ++= Seq()
 
 // Testing
 

--- a/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -630,4 +630,12 @@ trait ScalacOptions {
     optimizerInline,
     optimizerInlineFrom(inlineFromPackages: _*)
   )
+
+  /** Default options to exclude in console tasks
+    */
+  val defaultConsoleExclude: Set[ScalacOption] = privateWarnUnusedOptions ++
+    warnUnusedOptions ++
+    fatalWarningOptions +
+    privateWarnDeadCode +
+    warnDeadCode
 }

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -34,7 +34,7 @@ object TpolecatPlugin extends AutoPlugin {
       modeScalacOptions: Set[ScalacOption]
     ): Seq[String] = {
       val supportedOptions = (CrossVersion.partialVersion(version), version.split('.')) match {
-        case (Some((0, min)), _) => // dotty prereleases use 0 as major version
+        case (Some((0, _)), _) => // dotty prereleases use 0 as major version
           modeScalacOptions
             .filter(_.isSupported(V3_0_0)) // treat dotty prereleases as 3.0.0
         case (Some((maj, min)), Array(maj2, min2, patch))
@@ -49,16 +49,6 @@ object TpolecatPlugin extends AutoPlugin {
       }
 
       supportedOptions.toList.flatMap(_.tokens)
-    }
-
-    val tpolecatConsoleOptionsFilter = { options: Set[ScalacOption] =>
-      options.filterNot(
-        ScalacOptions.privateWarnUnusedOptions ++
-          ScalacOptions.warnUnusedOptions ++
-          ScalacOptions.fatalWarningOptions +
-          ScalacOptions.privateWarnDeadCode +
-          ScalacOptions.warnDeadCode
-      )
     }
 
     val tpolecatDefaultOptionsMode = settingKey[OptionsMode](
@@ -96,6 +86,10 @@ object TpolecatPlugin extends AutoPlugin {
     val tpolecatScalacOptions = settingKey[Set[ScalacOption]](
       "The set of scalac options that will be applied by the sbt-tpolecat plugin."
     )
+
+    val tpolecatExcludeOptions = settingKey[Set[ScalacOption]](
+      "The set of scalac options that will be excluded."
+    )
   }
 
   import autoImport._
@@ -129,7 +123,13 @@ object TpolecatPlugin extends AutoPlugin {
 
   override def projectSettings: Seq[Setting[_]] = Seq(
     Def.derive(
-      scalacOptions ++= scalacOptionsFor(scalaVersion.value, tpolecatScalacOptions.value)
+      scalacOptions := {
+        val previous   = scalacOptions.value
+        val scalaV     = scalaVersion.value
+        val filters    = scalacOptionsFor(scalaV, tpolecatExcludeOptions.value).toSet
+        val newOptions = scalacOptionsFor(scalaV, tpolecatScalacOptions.value)
+        (previous ++ newOptions).filterNot(filters).distinct
+      }
     ),
     tpolecatDevModeOptions := ScalacOptions.default,
     Def.derive(
@@ -145,7 +145,11 @@ object TpolecatPlugin extends AutoPlugin {
         case ReleaseMode => tpolecatReleaseModeOptions.value
       }
     }),
-    Compile / console / tpolecatScalacOptions ~= tpolecatConsoleOptionsFilter,
-    Test / console / tpolecatScalacOptions ~= tpolecatConsoleOptionsFilter
+    Compile / console / tpolecatExcludeOptions ++= ScalacOptions.defaultConsoleExclude,
+    Test / console / tpolecatExcludeOptions ++= ScalacOptions.defaultConsoleExclude
+  )
+
+  override def globalSettings: Seq[Def.Setting[_]] = Seq(
+    tpolecatExcludeOptions := Set.empty
   )
 }

--- a/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
+++ b/src/main/scala/io/github/davidgregory084/TpolecatPlugin.scala
@@ -118,7 +118,8 @@ object TpolecatPlugin extends AutoPlugin {
       else if (sys.env.contains(tpolecatCiModeEnvVar.value)) CiMode
       else if (sys.env.contains(tpolecatDevModeEnvVar.value)) DevMode
       else tpolecatDefaultOptionsMode.value
-    }
+    },
+    tpolecatDevModeOptions := ScalacOptions.default
   ) ++ commandAliases
 
   override def projectSettings: Seq[Setting[_]] = Seq(
@@ -131,7 +132,6 @@ object TpolecatPlugin extends AutoPlugin {
         (previous ++ newOptions).filterNot(filters).distinct
       }
     ),
-    tpolecatDevModeOptions := ScalacOptions.default,
     Def.derive(
       tpolecatCiModeOptions := tpolecatDevModeOptions.value + ScalacOptions.fatalWarnings
     ),

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -244,3 +244,37 @@ TaskKey[Unit]("checkReleaseMode") := {
 
   assertEquals(actualOptions, expectedOptions)
 }
+
+TaskKey[Unit]("checkConsoleScalacOptions") := {
+  val shouldBeMissing       = ScalacOptions.defaultConsoleExclude.flatMap(_.tokens).toSet
+  val testConsoleOptions    = (Test / console / scalacOptions).value
+  val compileConsoleOptions = (Compile / console / scalacOptions).value
+
+  testConsoleOptions.foreach { opt =>
+    assert(!shouldBeMissing.contains(opt), s"$opt is not excluded from Test/console")
+  }
+
+  compileConsoleOptions.foreach { opt =>
+    assert(!shouldBeMissing.contains(opt), s"$opt is not excluded from Compile/console")
+  }
+}
+
+addCommandAlias(
+  "addScalacOptionsToThisProject",
+  "set ThisProject / scalacOptions += \"non-existent-key\""
+)
+
+TaskKey[Unit]("checkThisProjectScalacOptions") := {
+  val options = (Compile / scalacOptions).value
+  assert(options.contains("non-existent-key"), "Scope ThisProject was ignored")
+}
+
+addCommandAlias(
+  "addScalacOptionsToThisBuild",
+  "set ThisBuild / scalacOptions += \"non-existent-key-2\""
+)
+
+TaskKey[Unit]("checkThisBuildScalacOptions") := {
+  val options = (Compile / scalacOptions).value
+  assert(options.contains("non-existent-key-2"), "Scope ThisBuild was ignored")
+}

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/test
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/test
@@ -13,3 +13,11 @@
 > tpolecatReleaseMode
 > +checkReleaseMode
 > +compile
+# Check console options
+> +checkConsoleScalacOptions
+# Check ThisProject
+> addScalacOptionsToThisProject
+> +checkThisProjectScalacOptions
+# Check ThisBuild (Ignored)
+> addScalacOptionsToThisBuild
+> +checkThisBuildScalacOptions

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/test
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/test
@@ -18,6 +18,6 @@
 # Check ThisProject
 > addScalacOptionsToThisProject
 > +checkThisProjectScalacOptions
-# Check ThisBuild (Ignored)
+# Check ThisBuild
 > addScalacOptionsToThisBuild
 > +checkThisBuildScalacOptions


### PR DESCRIPTION
#61 broke filtering of console `scalacOptions`

This is fixed with the help of a new setting key `tpolecatExcludeOptions` that is used to filter out all options and not just the current additions. 

Also, this PR adds tests to `console`, `ThisProject` and `ThisBuild` direct usages of `scalacOptions`