### PR TITLE
Extremely belatedly drop sbt-partial-unification dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@
 
 sbt-tpolecat is an SBT plugin for automagically configuring scalac options according to the project Scala version, inspired by Rob Norris ([@tpolecat](https://github.com/tpolecat))'s excellent series of blog posts providing [recommended options](https://tpolecat.github.io/2017/04/25/scalac-flags.html) to get the most out of the compiler.
 
-It also enables the excellent [sbt-partial-unification](https://github.com/fiadliel/sbt-partial-unification) plugin for those Scala versions where it is needed.
-
 As of version 0.1.11, it also supports setting options for Scala 3.x.
 
 ### Usage

--- a/build.sbt
+++ b/build.sbt
@@ -29,10 +29,6 @@ crossSbtVersions := Seq("1.6.2")
 
 enablePlugins(SbtPlugin)
 
-// Dependencies
-
-addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
-
 // License headers
 
 Compile / headerCreate := { (Compile / headerCreate).triggeredBy(Compile / compile).value }
@@ -56,7 +52,14 @@ mimaPreviousArtifacts := Set(
   projectID.value.withRevision("0.3.0")
 )
 
-mimaBinaryIssueFilters ++= Seq()
+mimaBinaryIssueFilters ++= Seq(
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.privatePartialUnification"
+  ),
+  ProblemFilters.exclude[ReversedMissingMethodProblem](
+    "io.github.davidgregory084.ScalacOptions.io$github$davidgregory084$ScalacOptions$_setter_$privatePartialUnification_="
+  )
+)
 
 // Testing
 

--- a/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalaVersion.scala
@@ -24,17 +24,18 @@ case class ScalaVersion(major: Long, minor: Long, patch: Long) {
 }
 
 object ScalaVersion {
-  val V2_11_0 = ScalaVersion(2, 11, 0)
-  val V2_12_0 = ScalaVersion(2, 12, 0)
-  val V2_12_2 = ScalaVersion(2, 12, 2)
-  val V2_13_0 = ScalaVersion(2, 13, 0)
-  val V2_13_2 = ScalaVersion(2, 13, 2)
-  val V2_13_3 = ScalaVersion(2, 13, 3)
-  val V2_13_4 = ScalaVersion(2, 13, 4)
-  val V2_13_5 = ScalaVersion(2, 13, 5)
-  val V2_13_6 = ScalaVersion(2, 13, 6)
-  val V3_0_0  = ScalaVersion(3, 0, 0)
-  val V3_1_0  = ScalaVersion(3, 1, 0)
+  val V2_11_0  = ScalaVersion(2, 11, 0)
+  val V2_11_11 = ScalaVersion(2, 11, 11)
+  val V2_12_0  = ScalaVersion(2, 12, 0)
+  val V2_12_2  = ScalaVersion(2, 12, 2)
+  val V2_13_0  = ScalaVersion(2, 13, 0)
+  val V2_13_2  = ScalaVersion(2, 13, 2)
+  val V2_13_3  = ScalaVersion(2, 13, 3)
+  val V2_13_4  = ScalaVersion(2, 13, 4)
+  val V2_13_5  = ScalaVersion(2, 13, 5)
+  val V2_13_6  = ScalaVersion(2, 13, 6)
+  val V3_0_0   = ScalaVersion(3, 0, 0)
+  val V3_1_0   = ScalaVersion(3, 1, 0)
 
   implicit val scalaVersionOrdering: Ordering[ScalaVersion] =
     Ordering.by(version => (version.major, version.minor, version.patch))

--- a/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
+++ b/src/main/scala/io/github/davidgregory084/ScalacOptions.scala
@@ -350,6 +350,15 @@ trait ScalacOptions {
   val privateKindProjector =
     privateOption("kind-projector", version => version >= V3_0_0)
 
+  /** Enables support for higher order unification in type constructor inference.
+    *
+    * Initially provided as a compiler option in the 2.12.x series to fix the infamous [[https://github.com/scala/bug/issues/2712 SI-2712]].
+    *
+    * Enabled by default in 2.13.0+ and no longer accepted by the compiler as an option.
+    */
+  val privatePartialUnification =
+    privateOption("partial-unification", version => version.isBetween(V2_11_11, V2_13_0))
+
   /** Private warning options (-Ywarn)
     */
   def privateWarnOption(name: String, isSupported: ScalaVersion => Boolean = _ => true) =
@@ -464,7 +473,8 @@ trait ScalacOptions {
     */
   val privateOptions: Set[ScalacOption] = ListSet(
     privateNoAdaptedArgs,
-    privateKindProjector
+    privateKindProjector,
+    privatePartialUnification
   ) ++ privateWarnOptions
 
   /** Warning options (-W)

--- a/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
+++ b/src/sbt-test/sbt-tpolecat/scalacOptions/build.sbt
@@ -51,6 +51,7 @@ val Scala211Options =
     "-Xlint:type-parameter-shadow",
     "-Xlint:unsound-match",
     "-Yno-adapted-args",
+    "-Ypartial-unification",
     "-Ywarn-dead-code",
     "-Ywarn-nullary-override",
     "-Ywarn-nullary-unit",
@@ -90,6 +91,7 @@ val Scala212Options =
     "-Xlint:type-parameter-shadow",
     "-Xlint:unsound-match",
     "-Yno-adapted-args",
+    "-Ypartial-unification",
     "-Ywarn-dead-code",
     "-Ywarn-extra-implicit",
     "-Ywarn-nullary-override",
@@ -184,8 +186,8 @@ TaskKey[Unit]("checkDevMode") := {
   val scalaV = scalaVersion.value
 
   val expectedOptions = scalaV match {
-    case Scala211 => Scala211Options ++ Seq("-Ypartial-unification")
-    case Scala212 => Scala212Options ++ Seq("-Ypartial-unification")
+    case Scala211 => Scala211Options
+    case Scala212 => Scala212Options
     case Scala213 => Scala213Options
     case Scala30  => Scala30Options
     case Scala31  => Scala31Options
@@ -200,8 +202,8 @@ TaskKey[Unit]("checkCiMode") := {
   val scalaV = scalaVersion.value
 
   val expectedOptions = scalaV match {
-    case Scala211 => Scala211Options ++ Seq("-Xfatal-warnings", "-Ypartial-unification")
-    case Scala212 => Scala212Options ++ Seq("-Xfatal-warnings", "-Ypartial-unification")
+    case Scala211 => Scala211Options ++ Seq("-Xfatal-warnings")
+    case Scala212 => Scala212Options ++ Seq("-Xfatal-warnings")
     case Scala213 => Scala213Options ++ Seq("-Xfatal-warnings")
     case Scala30  => Scala30Options ++ Seq("-Xfatal-warnings")
     case Scala31  => Scala31Options ++ Seq("-Xfatal-warnings")
@@ -217,17 +219,13 @@ TaskKey[Unit]("checkReleaseMode") := {
 
   val expectedOptions = scalaV match {
     case Scala211 =>
-      Scala211Options ++ Seq(
-        "-Xfatal-warnings",
-        "-Ypartial-unification"
-      )
+      Scala211Options ++ Seq("-Xfatal-warnings")
     case Scala212 =>
       Scala212Options ++ Seq(
         "-Xfatal-warnings",
         "-opt:l:method",
         "-opt:l:inline",
-        "-opt-inline-from:**",
-        "-Ypartial-unification"
+        "-opt-inline-from:**"
       )
     case Scala213 =>
       Scala213Options ++ Seq(


### PR DESCRIPTION
I moved away from 2.11 so long ago that I didn't even know it had a SI-2712 backport!